### PR TITLE
OEMB-issue: add quirk for Surface 3 with bad DMI table

### DIFF
--- a/drivers/platform/x86/surface3-wmi.c
+++ b/drivers/platform/x86/surface3-wmi.c
@@ -37,6 +37,13 @@ static const struct dmi_system_id surface3_dmi_table[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "Surface 3"),
 		},
 	},
+	{
+		.matches = {
+			DMI_MATCH(DMI_BIOS_VENDOR, "American Megatrends Inc."),
+			DMI_MATCH(DMI_SYS_VENDOR, "OEMB"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "OEMB"),
+		},
+	},
 #endif
 	{ }
 };

--- a/sound/soc/codecs/rt5645.c
+++ b/sound/soc/codecs/rt5645.c
@@ -3673,6 +3673,15 @@ static const struct dmi_system_id dmi_platform_data[] = {
 		.driver_data = (void *)&intel_braswell_platform_data,
 	},
 	{
+		.ident = "Microsoft Surface 3",
+		.matches = {
+			DMI_MATCH(DMI_BIOS_VENDOR, "American Megatrends Inc."),
+			DMI_MATCH(DMI_SYS_VENDOR, "OEMB"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "OEMB"),
+		},
+		.driver_data = (void *)&intel_braswell_platform_data,
+	},
+	{
 		/*
 		 * Match for the GPDwin which unfortunately uses somewhat
 		 * generic dmi strings, which is why we test for 4 strings.

--- a/sound/soc/intel/common/soc-acpi-intel-cht-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-cht-match.c
@@ -26,6 +26,12 @@ static const struct dmi_system_id cht_table[] = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "Surface 3"),
 		},
+		.callback = cht_surface_quirk_cb,
+		.matches = {
+			DMI_MATCH(DMI_BIOS_VENDOR, "American Megatrends Inc."),
+			DMI_MATCH(DMI_SYS_VENDOR, "OEMB"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "OEMB"),
+		},
 	},
 	{ }
 };


### PR DESCRIPTION
As a request from a person who is also suffering from "OEMB" issue on IRC channel.
Please port this into also 4.19 and 5.4 kernels when approved this PR, should apply with no conflicts.

By the way, the first patch (ASoC) is from Android-x86 project. The second patch is made by me referring to the first patch (they don't have a similar patch for surface3-wmi, so I made it).

---
Patch set for Surface 3 which is suffering from the "OEMB" problem.
On the affected systems, DMI table is broken and breaks
DMI matching used for quirk.

This patch will add the (broken) DMI info for the affected Surface 3.
Fixes broken Sound and surface3-wmi drivers on the affected systems.

On affected systems, dmidecode will look like this:
```
        $ sudo dmidecode
        [...]
        BIOS Information
            Vendor: American Megatrends Inc.
        [...]
        System Information
            Manufacturer: OEMB
            Product Name: OEMB
        [...]
```

Expected:
```
        $ sudo dmidecode
        [...]
        BIOS Information
            Vendor: (???, I think something like "Microsoft Corporation")
        [...]
        System Information
            Manufacturer: Microsoft Corporation
            Product Name: Surface 3
        [...]
```