### PR TITLE
v4.19: Revert upstreamed commits

### DIFF
--- a/arch/sparc/include/asm/io_64.h
+++ b/arch/sparc/include/asm/io_64.h
@@ -409,7 +409,6 @@ static inline void __iomem *ioremap(unsigned long offset, unsigned long size)
 }
 
 #define ioremap_nocache(X,Y)		ioremap((X),(Y))
-#define ioremap_uc(X,Y)			ioremap((X),(Y))
 #define ioremap_wc(X,Y)			ioremap((X),(Y))
 #define ioremap_wt(X,Y)			ioremap((X),(Y))
 

--- a/drivers/hid/hid-core.c
+++ b/drivers/hid/hid-core.c
@@ -741,10 +741,6 @@ static void hid_scan_feature_usage(struct hid_parser *parser, u32 usage)
 	if (usage == 0xff0000c5 && parser->global.report_count == 256 &&
 	    parser->global.report_size == 8)
 		parser->scan_flags |= HID_SCAN_FLAG_MT_WIN_8;
-
-	if (usage == 0xff0000c6 && parser->global.report_count == 1 &&
-	    parser->global.report_size == 8)
-		parser->scan_flags |= HID_SCAN_FLAG_MT_WIN_8;
 }
 
 static void hid_scan_collection(struct hid_parser *parser, unsigned type)


### PR DESCRIPTION
Revert the following two commits that are already upstreamed:
- "HID: Improve Windows Precision Touchpad detection."
- "sparc64: implement ioremap_uc"

Should apply with or without the PR:
- "[WIP] Backporting 5.3/5.4 changes into 4.19" #32