### PR TITLE
v4.19: ipts: Cleanup intel_guc_submission to pass checkpatch

### DIFF
--- a/drivers/gpu/drm/i915/intel_guc_submission.c
+++ b/drivers/gpu/drm/i915/intel_guc_submission.c
@@ -113,8 +113,7 @@ static int reserve_doorbell(struct intel_guc_client *client)
 	offset = 0;
 	if (IS_SKYLAKE(dev_priv) || IS_KABYLAKE(dev_priv)) {
 		end = GUC_NUM_DOORBELLS;
-	}
-	else {
+	} else {
 		end = GUC_NUM_DOORBELLS/2;
 		if (is_high_priority(client)) {
 			offset = end;


### PR DESCRIPTION
After backporting 5.3/5.4 changes, checkpatch added one error compared
to IPTS patch for 5.3:

        ERROR: else should follow close brace '}'
        #386: FILE: drivers/gpu/drm/i915/intel_guc_submission.c:117:
        +	}
        +	else {

This commit fixes the error.

The cause of the new error is that when this error was fixed in a
later kernel, the change was not backported to 4.19. On 5.3, the
error was already fixed when IPTS support (871f089) was added.