### PR TITLE
v5.5: mwifiex: disable ps_mode by default

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
@@ -457,6 +457,14 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
 		return -1;
 	}
 
+	if (ps_mode)
+		dev_warn(priv->adapter->dev,
+			    "WARN: Request to enable ps_mode received. Enabling it. "
+			    "Disable it if you encounter connection instability.\n");
+	else
+		dev_info(priv->adapter->dev,
+			    "Request to disable ps_mode received. Disabling it.\n");
+
 	return mwifiex_drv_set_power(priv, &ps_mode);
 }
 

--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
@@ -25,6 +25,11 @@
 static char *reg_alpha2;
 module_param(reg_alpha2, charp, 0);
 
+static bool allow_ps_mode;
+module_param(allow_ps_mode, bool, 0444);
+MODULE_PARM_DESC(allow_ps_mode,
+		 "allow WiFi power management to be enabled. (default: disallowed)");
+
 static const struct ieee80211_iface_limit mwifiex_ap_sta_limits[] = {
 	{
 		.max = 3, .types = BIT(NL80211_IFTYPE_STATION) |
@@ -438,6 +443,19 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
 			    "info: ignore timeout value for IEEE Power Save\n");
 
 	ps_mode = enabled;
+
+	/* Allow ps_mode to be enabled only when allow_ps_mode is set
+	 * (but always allow ps_mode to be disabled in case it gets enabled
+	 * for unknown reason and you want to disable it) */
+	if (ps_mode && !allow_ps_mode) {
+		dev_info(priv->adapter->dev,
+			    "Request to enable ps_mode received but it's disallowed "
+			    "by module parameter. Rejecting the request.\n");
+
+		/* Return negative value to inform userspace tools that setting
+		 * power_save to be enabled is not permitted. */
+		return -1;
+	}
 
 	return mwifiex_drv_set_power(priv, &ps_mode);
 }

--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2338,17 +2338,6 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 		if (ret)
 			return -1;
 
-		if (priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
-			/* Enable IEEE PS by default */
-			priv->adapter->ps_mode = MWIFIEX_802_11_POWER_MODE_PSP;
-			ret = mwifiex_send_cmd(priv,
-					       HostCmd_CMD_802_11_PS_MODE_ENH,
-					       EN_AUTO_PS, BITMAP_STA_PS, NULL,
-					       true);
-			if (ret)
-				return -1;
-		}
-
 		if (drcs) {
 			adapter->drcs_enabled = true;
 			if (ISSUPP_DRCS_ENABLED(adapter->fw_cap_info))


### PR DESCRIPTION
(This PR should also apply cleanly on 4.19 and 5.4)

It's known that ps_mode (power_save) causes connection instability. The change https://github.com/linux-surface/kernel/commit/264427bb5816c913a1abab9de59639eec299d972#diff-b645af90396992a038c24ef0d70bd262 reverted lines that forcibly overrides ps_mode to false.

And according to some reports, it seems that disabling ps_mode via config file is not so reliable.

So, this PR change back the ps_mode to disabled by default. Also, there may be no reason to keep it enabled by default if it's broken.

- What do you think, everyone? Should we really modify the driver to disable ps_mode by default by kernel side again?

---

I first tried to stop enabling ps_mode on initialization ("mwifiex: sta_cmd: do not enable ps_mode by default"). But NetworkManager still enabled ps_mode.

So, I also introduced a module parameter called `allow_ps_mode` and disallows enabling ps_mode by default. ("mwifiex: cfg80211: add allow_ps_mode module parameter")

The difference to the previously reverted lines (https://github.com/linux-surface/kernel/commit/264427bb5816c913a1abab9de59639eec299d972#diff-b645af90396992a038c24ef0d70bd262) is that we can still re-enable the ps_mode via module parameter just like other wifi drivers:
- https://github.com/torvalds/linux/blob/ca7e1fd1026c5af6a533b4b5447e1d2f153e28f2/drivers/net/wireless/intel/iwlwifi/iwl-drv.c#L1866-L1872 (`iwlwifi_mod_params.power_save`, iwlwifi)
- https://github.com/torvalds/linux/blob/a2d79c7174aeb43b13020dd53d85a7aefdd9f3e5/drivers/net/wireless/ath/ath9k/init.c#L67-L69 (`ath9k_ps_enable`, ath9k)

Also, note here that those two drivers also seem to disable power_save by default.

I also added a commit to print a message when the ps_mode state is going to be changed. Mainly for printing a warning to the user when ps_mode will get enabled. ("mwifiex: cfg80211: print message when changing ps_mode")