### PR TITLE
v4.19: Revert "HID: Do not abort on over-sized reports"

### DIFF
--- a/drivers/hid/hid-core.c
+++ b/drivers/hid/hid-core.c
@@ -290,9 +290,8 @@ static int hid_add_field(struct hid_parser *parser, unsigned report_type, unsign
 
 	/* Total size check: Allow for possible report index byte */
 	if (report->size > (HID_MAX_BUFFER_SIZE - 1) << 3) {
-		hid_warn(parser->device, "report is too long (%u), skipping\n",
-			 report->size);
-		return 0;
+		hid_err(parser->device, "report is too long\n");
+		return -1;
 	}
 
 	if (!parser->local.usage_index) /* Ignore padding fields */


### PR DESCRIPTION
Fixes #37

---
This reverts commit 44c036ba808e1df71a4262999399a160bdd0d519.

Reason for revert:
  Following upstream fixes incoming
  - fa616c09626198ecea736fff251b72f8116c19f4
    (HID: core: increase HID report buffer size to 8KiB)
  - 75c3955b160d32a7faac6db094960c35723eebd4
    (HID: core: fix off-by-one memset in hid_report_raw_event())