### PR TITLE
Fixup: ipts: Do not forward report on overflow

### DIFF
--- a/drivers/misc/ipts/hid.c
+++ b/drivers/misc/ipts/hid.c
@@ -304,7 +304,7 @@ int ipts_handle_hid_data(struct ipts_info *ipts,
 	switch (raw_header->data_type) {
 	case TOUCH_RAW_DATA_TYPE_HID_REPORT: {
 		if (raw_header->raw_data_size_bytes > HID_MAX_BUFFER_SIZE) {
-			ipts_err(ipts, "input report too large (%lu bytes), skipping",
+			ipts_err(ipts, "input report too large (%u bytes), skipping",
 				 raw_header->raw_data_size_bytes);
 			break;
 		}


### PR DESCRIPTION
When building module with commit 589ab3dbf4af3412daa40524024e58f8b548d263, compiler gave me a warning.

---
Compiler outputs the following warning on build:

        CC [M]  drivers/misc/ipts/hid.o
        In file included from ./include/linux/input.h:22,
                        from ./include/linux/hid.h:36,
                        from drivers/misc/ipts/hid.c:11:
        drivers/misc/ipts/hid.c: In function ‘ipts_handle_hid_data’:
        drivers/misc/ipts/hid.c:307:19: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘u32’ {aka ‘unsigned int’} [-Wformat=]
        307 |    ipts_err(ipts, "input report too large (%lu bytes), skipping",
            |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        ./include/linux/device.h:1362:22: note: in definition of macro ‘dev_fmt’
        1362 | #define dev_fmt(fmt) fmt
            |                      ^~~
        drivers/misc/ipts/ipts.h:107:2: note: in expansion of macro ‘dev_err’
        107 |  dev_err(&ipts->cldev->dev, format, ##arg)
            |  ^~~~~~~
        drivers/misc/ipts/hid.c:307:4: note: in expansion of macro ‘ipts_err’
        307 |    ipts_err(ipts, "input report too large (%lu bytes), skipping",
            |    ^~~~~~~~
        drivers/misc/ipts/hid.c:307:46: note: format string is defined here
        307 |    ipts_err(ipts, "input report too large (%lu bytes), skipping",
            |                                            ~~^
            |                                              |
            |                                              long unsigned int
            |                                            %u

This commit fixes the warning by changing %lu to %u in accordance with
the given warning.