### PR TITLE
Backport simplified feedback sending and remove no_feedback

### DIFF
--- a/drivers/misc/ipts/companion.c
+++ b/drivers/misc/ipts/companion.c
@@ -209,22 +209,3 @@ config_fallback:
 	return ret;
 
 }
-
-unsigned int ipts_get_quirks(void)
-{
-	unsigned int ret;
-
-	// Make sure that access to the companion is synchronized
-	mutex_lock(&ipts_companion_lock);
-
-	// If the companion is ignored, or doesn't exist, assume that
-	// the device doesn't have any quirks
-	if (ipts_modparams.ignore_companion || ipts_companion == NULL)
-		ret = IPTS_QUIRK_NONE;
-	else
-		ret = ipts_companion->get_quirks(ipts_companion);
-
-	mutex_unlock(&ipts_companion_lock);
-
-	return ret;
-}

--- a/drivers/misc/ipts/companion.h
+++ b/drivers/misc/ipts/companion.h
@@ -15,7 +15,6 @@
 #include "ipts.h"
 
 bool ipts_companion_available(void);
-unsigned int ipts_get_quirks(void);
 
 int ipts_request_firmware(const struct firmware **fw, const char *name,
 		struct device *device);

--- a/drivers/misc/ipts/companion/ipts-surface.c
+++ b/drivers/misc/ipts/companion/ipts-surface.c
@@ -34,13 +34,13 @@ struct ipts_surface_data {
 // Surface Book 1 / Surface Studio
 static const struct ipts_surface_data ipts_surface_mshw0076 = {
 	.hid = "MSHW0076",
-	.quirks = IPTS_QUIRK_NO_FEEDBACK,
+	.quirks = IPTS_QUIRK_NONE,
 };
 
 // Surface Pro 4
 static const struct ipts_surface_data ipts_surface_mshw0078 = {
 	.hid = "MSHW0078",
-	.quirks = IPTS_QUIRK_NO_FEEDBACK,
+	.quirks = IPTS_QUIRK_NONE,
 };
 
 // Surface Laptop 1 / 2

--- a/drivers/misc/ipts/companion/ipts-surface.c
+++ b/drivers/misc/ipts/companion/ipts-surface.c
@@ -26,53 +26,6 @@
 	MODULE_FIRMWARE("intel/ipts/" X "/vendor_desc.bin");		\
 	MODULE_FIRMWARE("intel/ipts/" X "/vendor_kernel.bin")
 
-struct ipts_surface_data {
-	const char *hid;
-	unsigned int quirks;
-};
-
-// Surface Book 1 / Surface Studio
-static const struct ipts_surface_data ipts_surface_mshw0076 = {
-	.hid = "MSHW0076",
-	.quirks = IPTS_QUIRK_NONE,
-};
-
-// Surface Pro 4
-static const struct ipts_surface_data ipts_surface_mshw0078 = {
-	.hid = "MSHW0078",
-	.quirks = IPTS_QUIRK_NONE,
-};
-
-// Surface Laptop 1 / 2
-static const struct ipts_surface_data ipts_surface_mshw0079 = {
-	.hid = "MSHW0079",
-	.quirks = IPTS_QUIRK_NONE,
-};
-
-// Surface Pro 5 / 6
-static const struct ipts_surface_data ipts_surface_mshw0101 = {
-	.hid = "MSHW0101",
-	.quirks = IPTS_QUIRK_NONE,
-};
-
-// Surface Book 2 15"
-static const struct ipts_surface_data ipts_surface_mshw0102 = {
-	.hid = "MSHW0102",
-	.quirks = IPTS_QUIRK_NONE,
-};
-
-// Unknown, but firmware exists
-static const struct ipts_surface_data ipts_surface_mshw0103 = {
-	.hid = "MSHW0103",
-	.quirks = IPTS_QUIRK_NONE,
-};
-
-// Surface Book 2 13"
-static const struct ipts_surface_data ipts_surface_mshw0137 = {
-	.hid = "MSHW0137",
-	.quirks = IPTS_QUIRK_NONE,
-};
-
 /*
  * Checkpatch complains about the following lines because it sees them as
  * header files mixed with .c files. However, forward declaration is perfectly
@@ -119,7 +72,6 @@ static struct ipts_bin_fw_info *ipts_surface_fw_config[] = {
 static struct ipts_companion ipts_surface_companion = {
 	.firmware_request = &ipts_surface_request_firmware,
 	.firmware_config = ipts_surface_fw_config,
-	.get_quirks = &ipts_surface_get_quirks,
 	.name = "ipts_surface",
 };
 
@@ -128,44 +80,26 @@ int ipts_surface_request_firmware(struct ipts_companion *companion,
 		struct device *device)
 {
 	char fw_path[MAX_IOCL_FILE_PATH_LEN];
-	struct ipts_surface_data *data;
 
 	if (companion == NULL || companion->data == NULL)
 		return -ENOENT;
 
-	data = (struct ipts_surface_data *)companion->data;
-
 	snprintf(fw_path, MAX_IOCL_FILE_PATH_LEN, IPTS_SURFACE_FW_PATH_FMT,
-		data->hid, name);
+		(const char *)companion->data, name);
 	return request_firmware(fw, fw_path, device);
-}
-
-unsigned int ipts_surface_get_quirks(struct ipts_companion *companion)
-{
-	struct ipts_surface_data *data;
-
-	// In case something went wrong, assume that the
-	// device doesn't have any quirks
-	if (companion == NULL || companion->data == NULL)
-		return IPTS_QUIRK_NONE;
-
-	data = (struct ipts_surface_data *)companion->data;
-
-	return data->quirks;
 }
 
 static int ipts_surface_probe(struct platform_device *pdev)
 {
 	int r;
-	const struct ipts_surface_data *data =
-		acpi_device_get_match_data(&pdev->dev);
+	struct acpi_device *adev = ACPI_COMPANION(&pdev->dev);
 
-	if (!data) {
+	if (!adev) {
 		dev_err(&pdev->dev, "Unable to find ACPI info for device\n");
 		return -ENODEV;
 	}
 
-	ipts_surface_companion.data = (void *)data;
+	ipts_surface_companion.data = (void *)acpi_device_hid(adev);
 
 	r = ipts_add_companion(&ipts_surface_companion);
 	if (r) {
@@ -189,13 +123,13 @@ static int ipts_surface_remove(struct platform_device *pdev)
 }
 
 static const struct acpi_device_id ipts_surface_acpi_match[] = {
-	{ "MSHW0076", (unsigned long)&ipts_surface_mshw0076 },
-	{ "MSHW0078", (unsigned long)&ipts_surface_mshw0078 },
-	{ "MSHW0079", (unsigned long)&ipts_surface_mshw0079 },
-	{ "MSHW0101", (unsigned long)&ipts_surface_mshw0101 },
-	{ "MSHW0102", (unsigned long)&ipts_surface_mshw0102 },
-	{ "MSHW0103", (unsigned long)&ipts_surface_mshw0103 },
-	{ "MSHW0137", (unsigned long)&ipts_surface_mshw0137 },
+	{ "MSHW0076", 0 }, // Surface Book 1 / Surface Studio
+	{ "MSHW0078", 0 }, // Surface Pro 4
+	{ "MSHW0079", 0 }, // Surface Laptop 1 / 2
+	{ "MSHW0101", 0 }, // Surface Book 2 15"
+	{ "MSHW0102", 0 }, // Surface Pro 5 / 6
+	{ "MSHW0103", 0 }, // Unknown
+	{ "MSHW0137", 0 }, // Surface Book 2
 	{ },
 };
 MODULE_DEVICE_TABLE(acpi, ipts_surface_acpi_match);
@@ -220,5 +154,4 @@ IPTS_SURFACE_FIRMWARE("MSHW0079");
 IPTS_SURFACE_FIRMWARE("MSHW0101");
 IPTS_SURFACE_FIRMWARE("MSHW0102");
 IPTS_SURFACE_FIRMWARE("MSHW0103");
-
 IPTS_SURFACE_FIRMWARE("MSHW0137");

--- a/drivers/misc/ipts/params.c
+++ b/drivers/misc/ipts/params.c
@@ -18,7 +18,6 @@ struct ipts_params ipts_modparams = {
 	.ignore_fw_fallback = false,
 	.ignore_config_fallback = false,
 	.ignore_companion = false,
-	.no_feedback = -1,
 
 	.debug = false,
 	.debug_thread = false,
@@ -32,9 +31,6 @@ IPTS_PARAM(ignore_config_fallback, bool, 0400,
 );
 IPTS_PARAM(ignore_companion, bool, 0400,
 	"Don't use a companion driver to load firmware. (default: false)"
-);
-IPTS_PARAM(no_feedback, int, 0644,
-	"Disable sending feedback to ME (can prevent crashes on Skylake). (-1=auto [default], 0=false, 1=true)"
 );
 
 IPTS_PARAM(debug, bool, 0400,

--- a/drivers/misc/ipts/params.h
+++ b/drivers/misc/ipts/params.h
@@ -15,7 +15,6 @@ struct ipts_params {
 	bool ignore_fw_fallback;
 	bool ignore_config_fallback;
 	bool ignore_companion;
-	int no_feedback;
 
 	bool debug;
 	bool debug_thread;

--- a/include/linux/ipts-companion.h
+++ b/include/linux/ipts-companion.h
@@ -14,7 +14,6 @@
 #include <linux/ipts-binary.h>
 
 struct ipts_companion {
-	unsigned int (*get_quirks)(struct ipts_companion *companion);
 	int (*firmware_request)(struct ipts_companion *companion,
 		const struct firmware **fw,
 		const char *name, struct device *device);

--- a/include/linux/ipts.h
+++ b/include/linux/ipts.h
@@ -15,6 +15,5 @@
 #define MAX_IOCL_FILE_PATH_LEN 256
 
 #define IPTS_QUIRK_NONE        0
-#define IPTS_QUIRK_NO_FEEDBACK BIT(0)
 
 #endif // IPTS_H


### PR DESCRIPTION
@kitakar5525 and I figured out that the feedback sending I implemented for the new IPTS driver doesn't appear to cause the crashes on gen4 devices that lead to no_feedback being implemented. I backported it to this driver, and it works here as well: No crashes on a device that required no_feedback before.

The difference between the old implementation and this one is, that the old one got the feedback data that it sent through the GuC. We have no idea what data is sent, and how the ME reacts to it. Because the GuC is not useable on the new driver, it will send a buffer that contains nothing but the transaction / buffer ID. 

This causes an "Invalid Parameters" error from the ME, but touch data continues to be written into the buffers (as opposed to not sending feedback at all). The "Invalid Parameters" error has been silenced on the feedback command for that reason.

The other commits remove the now obsolete code for device-specific quirks. If we ever need quirks again, we can just revert the last commit and then add whatever quirk is required to the base code.

Note: This has only been tested on one device to verify that it fixes the issue with no_feedback. I haven't tested it on any other device, so testing is welcome!