### PR TITLE
mwifiex: split large commit into three commits

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -149,38 +149,35 @@ static bool mwifiex_pcie_ok_to_access_hw(struct mwifiex_adapter *adapter)
  */
 static int mwifiex_pcie_suspend(struct device *dev)
 {
-	struct pci_dev *pdev = to_pci_dev(dev);
-	struct pcie_service_card *card = pci_get_drvdata(pdev);
 	struct mwifiex_adapter *adapter;
-	struct mwifiex_private *priv;
-	const struct mwifiex_pcie_card_reg *reg;
-	u32 fw_status;
-	int ret;
+	struct pcie_service_card *card = dev_get_drvdata(dev);
+
 
 	/* Might still be loading firmware */
 	wait_for_completion(&card->fw_done);
 
 	adapter = card->adapter;
-	if (!adapter || !adapter->priv_num)
+	if (!adapter) {
+		dev_err(dev, "adapter is not valid\n");
 		return 0;
-
-	reg = card->pcie.reg;
-	if (reg)
-		ret = mwifiex_read_reg(adapter, reg->fw_status, &fw_status);
-	else
-		fw_status = -1;
-
-	if (fw_status == FIRMWARE_READY_PCIE && !adapter->mfg_mode) {
-		mwifiex_deauthenticate_all(adapter);
-
-		priv = mwifiex_get_priv(adapter, MWIFIEX_BSS_ROLE_ANY);
-
-		mwifiex_disable_auto_ds(priv);
-
-		mwifiex_init_shutdown_fw(priv, MWIFIEX_FUNC_SHUTDOWN);
 	}
 
-	mwifiex_remove_card(adapter);
+	mwifiex_enable_wake(adapter);
+
+	/* Enable the Host Sleep */
+	if (!mwifiex_enable_hs(adapter)) {
+		mwifiex_dbg(adapter, ERROR,
+			    "cmd: failed to suspend\n");
+		clear_bit(MWIFIEX_IS_HS_ENABLING, &adapter->work_flags);
+		mwifiex_disable_wake(adapter);
+		return -EFAULT;
+	}
+
+	flush_workqueue(adapter->workqueue);
+
+	/* Indicate device suspended */
+	set_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags);
+	clear_bit(MWIFIEX_IS_HS_ENABLING, &adapter->work_flags);
 
 	return 0;
 }
@@ -195,29 +192,28 @@ static int mwifiex_pcie_suspend(struct device *dev)
  */
 static int mwifiex_pcie_resume(struct device *dev)
 {
-	struct pci_dev *pdev = to_pci_dev(dev);
-	struct pcie_service_card *card = pci_get_drvdata(pdev);
-	int ret;
+	struct mwifiex_adapter *adapter;
+	struct pcie_service_card *card = dev_get_drvdata(dev);
 
-	pr_debug("info: vendor=0x%4.04X device=0x%4.04X rev=%d\n",
-		 pdev->vendor, pdev->device, pdev->revision);
 
-	init_completion(&card->fw_done);
-
-	card->dev = pdev;
-
-	/* device tree node parsing and platform specific configuration */
-	if (pdev->dev.of_node) {
-		ret = mwifiex_pcie_probe_of(&pdev->dev);
-		if (ret)
-			return ret;
+	if (!card->adapter) {
+		dev_err(dev, "adapter structure is not valid\n");
+		return 0;
 	}
 
-	if (mwifiex_add_card(card, &card->fw_done, &pcie_ops,
-			MWIFIEX_PCIE, &pdev->dev)) {
-		pr_err("%s failed\n", __func__);
-		return -1;
+	adapter = card->adapter;
+
+	if (!test_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags)) {
+		mwifiex_dbg(adapter, WARN,
+			    "Device already resumed\n");
+		return 0;
 	}
+
+	clear_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags);
+
+	mwifiex_cancel_hs(mwifiex_get_priv(adapter, MWIFIEX_BSS_ROLE_STA),
+			  MWIFIEX_ASYNC_CMD);
+	mwifiex_disable_wake(adapter);
 
 	return 0;
 }
@@ -270,8 +266,6 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
 		pr_err("%s failed\n", __func__);
 		return -1;
 	}
-
-	pdev->bus->self->bridge_d3 = false;
 
 	return 0;
 }

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -240,7 +240,12 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
 					const struct pci_device_id *ent)
 {
 	struct pcie_service_card *card;
+	struct pci_dev *parent_pdev = pci_upstream_bridge(pdev);
 	int ret;
+
+	/* disable bridge_d3 to fix driver crashing after suspend on gen4+
+	 * Surface devices */
+	parent_pdev->bridge_d3 = false;
 
 	pr_debug("info: vendor=0x%4.04X device=0x%4.04X rev=%d\n",
 		 pdev->vendor, pdev->device, pdev->revision);

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -146,38 +146,45 @@ static bool mwifiex_pcie_ok_to_access_hw(struct mwifiex_adapter *adapter)
  *
  * If already not suspended, this function allocates and sends a host
  * sleep activate request to the firmware and turns off the traffic.
+ *
+ * XXX: ignoring all the above comment and just removes the card to
+ * fix S0ix and "AP scanning (sometimes) not working after suspend".
+ * Required code is extracted from mwifiex_pcie_remove().
  */
 static int mwifiex_pcie_suspend(struct device *dev)
 {
+	struct pci_dev *pdev = to_pci_dev(dev);
+	struct pcie_service_card *card = pci_get_drvdata(pdev);
 	struct mwifiex_adapter *adapter;
-	struct pcie_service_card *card = dev_get_drvdata(dev);
-
+	struct mwifiex_private *priv;
+	const struct mwifiex_pcie_card_reg *reg;
+	u32 fw_status;
+	int ret;
 
 	/* Might still be loading firmware */
 	wait_for_completion(&card->fw_done);
 
 	adapter = card->adapter;
-	if (!adapter) {
-		dev_err(dev, "adapter is not valid\n");
+	if (!adapter || !adapter->priv_num)
 		return 0;
+
+	reg = card->pcie.reg;
+	if (reg)
+		ret = mwifiex_read_reg(adapter, reg->fw_status, &fw_status);
+	else
+		fw_status = -1;
+
+	if (fw_status == FIRMWARE_READY_PCIE && !adapter->mfg_mode) {
+		mwifiex_deauthenticate_all(adapter);
+
+		priv = mwifiex_get_priv(adapter, MWIFIEX_BSS_ROLE_ANY);
+
+		mwifiex_disable_auto_ds(priv);
+
+		mwifiex_init_shutdown_fw(priv, MWIFIEX_FUNC_SHUTDOWN);
 	}
 
-	mwifiex_enable_wake(adapter);
-
-	/* Enable the Host Sleep */
-	if (!mwifiex_enable_hs(adapter)) {
-		mwifiex_dbg(adapter, ERROR,
-			    "cmd: failed to suspend\n");
-		clear_bit(MWIFIEX_IS_HS_ENABLING, &adapter->work_flags);
-		mwifiex_disable_wake(adapter);
-		return -EFAULT;
-	}
-
-	flush_workqueue(adapter->workqueue);
-
-	/* Indicate device suspended */
-	set_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags);
-	clear_bit(MWIFIEX_IS_HS_ENABLING, &adapter->work_flags);
+	mwifiex_remove_card(adapter);
 
 	return 0;
 }
@@ -189,31 +196,35 @@ static int mwifiex_pcie_suspend(struct device *dev)
  *
  * If already not resumed, this function turns on the traffic and
  * sends a host sleep cancel request to the firmware.
+ *
+ * XXX: ignoring all the above comment and probes the card that was
+ * removed on suspend. Required code is extracted from mwifiex_pcie_probe().
  */
 static int mwifiex_pcie_resume(struct device *dev)
 {
-	struct mwifiex_adapter *adapter;
-	struct pcie_service_card *card = dev_get_drvdata(dev);
+	struct pci_dev *pdev = to_pci_dev(dev);
+	struct pcie_service_card *card = pci_get_drvdata(pdev);
+	int ret;
 
+	pr_debug("info: vendor=0x%4.04X device=0x%4.04X rev=%d\n",
+		 pdev->vendor, pdev->device, pdev->revision);
 
-	if (!card->adapter) {
-		dev_err(dev, "adapter structure is not valid\n");
-		return 0;
+	init_completion(&card->fw_done);
+
+	card->dev = pdev;
+
+	/* device tree node parsing and platform specific configuration */
+	if (pdev->dev.of_node) {
+		ret = mwifiex_pcie_probe_of(&pdev->dev);
+		if (ret)
+			return ret;
 	}
 
-	adapter = card->adapter;
-
-	if (!test_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags)) {
-		mwifiex_dbg(adapter, WARN,
-			    "Device already resumed\n");
-		return 0;
+	if (mwifiex_add_card(card, &card->fw_done, &pcie_ops,
+			MWIFIEX_PCIE, &pdev->dev)) {
+		pr_err("%s failed\n", __func__);
+		return -1;
 	}
-
-	clear_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags);
-
-	mwifiex_cancel_hs(mwifiex_get_priv(adapter, MWIFIEX_BSS_ROLE_STA),
-			  MWIFIEX_ASYNC_CMD);
-	mwifiex_disable_wake(adapter);
 
 	return 0;
 }

--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2265,13 +2265,14 @@ int mwifiex_sta_prepare_cmd(struct mwifiex_private *priv, uint16_t cmd_no,
 int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 {
 	struct mwifiex_adapter *adapter = priv->adapter;
+	int ret;
 	struct mwifiex_ds_11n_amsdu_aggr_ctrl amsdu_aggr_ctrl;
+	struct mwifiex_ds_auto_ds auto_ds;
 	enum state_11d_t state_11d;
 	struct mwifiex_ds_11n_tx_cfg tx_cfg;
 	u8 sdio_sp_rx_aggr_enable;
 	u16 packet_aggr_enable;
 	int data;
-	int ret;
 
 	if (first_sta) {
 		if (priv->adapter->iface_type == MWIFIEX_PCIE) {
@@ -2382,6 +2383,18 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 			       &priv->curr_pkt_filter, true);
 	if (ret)
 		return -1;
+
+	if (!disable_auto_ds && first_sta &&
+	    priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
+		/* Enable auto deep sleep */
+		auto_ds.auto_ds = DEEP_SLEEP_ON;
+		auto_ds.idle_time = DEEP_SLEEP_IDLE_TIME;
+		ret = mwifiex_send_cmd(priv, HostCmd_CMD_802_11_PS_MODE_ENH,
+				       EN_AUTO_PS, BITMAP_AUTO_DS,
+				       &auto_ds, true);
+		if (ret)
+			return -1;
+	}
 
 	if (priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
 		/* Send cmd to FW to enable/disable 11D function */

--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2254,7 +2254,6 @@ int mwifiex_sta_prepare_cmd(struct mwifiex_private *priv, uint16_t cmd_no,
  *      - Function init (for first interface only)
  *      - Read MAC address (for first interface only)
  *      - Reconfigure Tx buffer size (for first interface only)
- *      - Enable auto deep sleep (for first interface only)
  *      - Get Tx rate
  *      - Get Tx power
  *      - Set IBSS coalescing status
@@ -2267,7 +2266,6 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 	struct mwifiex_adapter *adapter = priv->adapter;
 	int ret;
 	struct mwifiex_ds_11n_amsdu_aggr_ctrl amsdu_aggr_ctrl;
-	struct mwifiex_ds_auto_ds auto_ds;
 	enum state_11d_t state_11d;
 	struct mwifiex_ds_11n_tx_cfg tx_cfg;
 	u8 sdio_sp_rx_aggr_enable;
@@ -2384,17 +2382,10 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 	if (ret)
 		return -1;
 
-	if (!disable_auto_ds && first_sta &&
-	    priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
-		/* Enable auto deep sleep */
-		auto_ds.auto_ds = DEEP_SLEEP_ON;
-		auto_ds.idle_time = DEEP_SLEEP_IDLE_TIME;
-		ret = mwifiex_send_cmd(priv, HostCmd_CMD_802_11_PS_MODE_ENH,
-				       EN_AUTO_PS, BITMAP_AUTO_DS,
-				       &auto_ds, true);
-		if (ret)
-			return -1;
-	}
+	/* Not enabling auto deep sleep (auto_ds) by default. Enabling
+	 * this reportedly causes "suspend/resume fails when not connected
+	 * to an Access Point." Therefore, the relevant code was removed
+	 * from here. */
 
 	if (priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
 		/* Send cmd to FW to enable/disable 11D function */


### PR DESCRIPTION
(The first revert commit does not apply cleanly on v4.19 branch. So, I'll make the same change to v5.4 and v4.19 branch once this PR gets approved. Or let me know if you guys want to do it by yourself.)

This PR
1) reverts the large commit 456cdc416f6e ("wireless/mwifiex: Fix S0ix / suspend")
2) split the commit into three small commits

So, no functional changes are intended. Just split the commit to describe what each part does.

There are small changes from the reverted commit.
1) added a description to the top of suspend()/resume() functions (starting with 'XXX:')
2) used `pci_upstream_bridge()` instead of `bus->self->` and placed `bridge_d3` thing to the top of probe()
3) removed description regarding auto_ds from the top of the function
4) not changing the location of `int ret;`; the previous commit changed the location (I feel this is rather cleaner, but I followed the upstream code)
5) added a comment where the removed code existed
6) added commit message to each commit