### PR TITLE
mwifiex: sta_cmd: add comment for not enabling ps_mode by default

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2338,6 +2338,11 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 		if (ret)
 			return -1;
 
+		/* Not enabling ps_mode (IEEE power_save) by default. Enabling
+		 * this causes connection instability, especially on 5GHz APs
+		 * and eventually causes "firmware wakeup failed". Therefore,
+		 * the relevant code was removed from here. */
+
 		if (drcs) {
 			adapter->drcs_enabled = true;
 			if (ISSUPP_DRCS_ENABLED(adapter->fw_cap_info))


### PR DESCRIPTION
(once this PR gets approved, I'll make the same change to v4.19 and v5.4 branches or let me know if you guys want to do it by yourself.)

The commit 541813622549 ("mwifiex: sta_cmd: do not enable ps_mode by
default") stopped enabling ps_mode by default by just removing the
relevant code. But it's better to leave a comment there.

This commit adds a comment where the related code existed.

Signed-off-by: Tsuchiya Yuto (kitakar5525) <kitakar@gmail.com>