### PR TITLE
v4.19: media: ipu3-cio2: Allow probe to succeed if there are no sensors connected

### DIFF
--- a/drivers/media/pci/intel/ipu3/ipu3-cio2.c
+++ b/drivers/media/pci/intel/ipu3/ipu3-cio2.c
@@ -1810,7 +1810,8 @@ static int cio2_pci_probe(struct pci_dev *pci_dev,
 
 	/* Register notifier for subdevices we care */
 	r = cio2_notifier_init(cio2);
-	if (r)
+	/* Proceed without sensors connected to allow the device to suspend. */
+	if (r && r != -ENODEV)
 		goto fail_cio2_queue_exit;
 
 	r = devm_request_irq(&pci_dev->dev, pci_dev->irq, cio2_irq,


### PR DESCRIPTION
(patch for 4.19 branch)

cherry-picked a commit from newer kernel. I guess S0ix can't be achieved without this commit on ipu3 devices on v4.19 kernels.

**NOTE:** Regarding devices that uses ipu3, I only own Surface Book 1, which can't achieve S0ix on the latest kernels (5.6.11-arch1-1-surface) anyway. So, I can't test myself. 
So, only *guessing* that this commit is needed for ipu3 devices to achieve S0ix. But applying this patch does no harm. So, let's apply this patch ?

(I'm curious if S0ix can be achieved on v4.19 kernels with devices that can achieve S0ix on the latest kernel. I don't request but if someone dares to test, let me know.)

---

The device won't be powered off on systems that have no sensors connected
unless it has a driver bound to it. Allow that to happen even if there are
no sensors connected to cio2.

Reviewed-by: Rajneesh Bhardwaj <rajneesh.bhardwaj@linux.intel.com>
Tested-by: Rajneesh Bhardwaj <rajneesh.bhardwaj@linux.intel.com>
Signed-off-by: Sakari Ailus <sakari.ailus@linux.intel.com>
Signed-off-by: Mauro Carvalho Chehab <mchehab+samsung@kernel.org>

(cherry picked from commit b9da9b376711f61d0e3c3e419ee348249ca2bd80)
[Reason for cherry-picking this commit:
  I guess S0ix can't be achieved without this commit on ipu3 devices on
  v4.19 kernels.]
Signed-off-by: Tsuchiya Yuto (kitakar5525) <kitakar@gmail.com>