### PR TITLE
v4.19: pwm: lpss: Add ACPI HID for second PWM controller on Cherry Trail devices

### DIFF
--- a/drivers/pwm/pwm-lpss-platform.c
+++ b/drivers/pwm/pwm-lpss-platform.c
@@ -81,6 +81,7 @@ static SIMPLE_DEV_PM_OPS(pwm_lpss_platform_pm_ops,
 static const struct acpi_device_id pwm_lpss_acpi_match[] = {
 	{ "80860F09", (unsigned long)&pwm_lpss_byt_info },
 	{ "80862288", (unsigned long)&pwm_lpss_bsw_info },
+	{ "80862289", (unsigned long)&pwm_lpss_bsw_info },
 	{ "80865AC8", (unsigned long)&pwm_lpss_bxt_info },
 	{ },
 };


### PR DESCRIPTION
(patch for 4.19 branch)

cherry-picked a commit from newer kernel hoping that this patch improves battery life on Surface 3.

Surface 3 can achieve S0ix without this commit on v4.19 kernels anyway but the second PWM controller actually exists on Surface 3 according to acpidump.
Applying this patch does no harm. So, let's apply this patch anyway hoping longer battery life?

If you don't want to add patches unnecessarily, I can test battery life before merging this patch...

---

The second PWM controller on Cherry Trail devices uses a separate ACPI
HID: "80862289", add this so that the driver will properly bind to the
second PWM controller.

The second PWM controller is usually not used, the main thing gained by
this is properly putting the PWM controller in D3 on suspend.

Reviewed-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
Signed-off-by: Hans de Goede <hdegoede@redhat.com>
Signed-off-by: Thierry Reding <thierry.reding@gmail.com>

(cherry picked from commit 1688c8717118f37191d824862a006c8373d261de)
[Reason for cherry-picking this commit:
  to try to improve S0ix on Cherry Trail devices such as Surface 3 on
  kernels below v4.20-rc1.

  TODO: Surface 3 can achieve S0ix without this commit on v4.19 kernels
        anyway but the second PWM controller actually exists on Surface 3
        according to acpidump. How does this commit improve S0ix on
        Surface 3 regarding battery life?]
Signed-off-by: Tsuchiya Yuto (kitakar5525) <kitakar@gmail.com>