### PR TITLE
v4.19: ioremap_uc: revert commits that were upstreamed now

### DIFF
--- a/drivers/mfd/intel-lpss.c
+++ b/drivers/mfd/intel-lpss.c
@@ -397,7 +397,7 @@ int intel_lpss_probe(struct device *dev,
 	if (!lpss)
 		return -ENOMEM;
 
-	lpss->priv = devm_ioremap_uc(dev, info->mem->start + LPSS_PRIV_OFFSET,
+	lpss->priv = devm_ioremap(dev, info->mem->start + LPSS_PRIV_OFFSET,
 				  LPSS_PRIV_SIZE);
 	if (!lpss->priv)
 		return -ENOMEM;

--- a/include/linux/io.h
+++ b/include/linux/io.h
@@ -75,8 +75,6 @@ static inline void devm_ioport_unmap(struct device *dev, void __iomem *addr)
 
 void __iomem *devm_ioremap(struct device *dev, resource_size_t offset,
 			   resource_size_t size);
-void __iomem *devm_ioremap_uc(struct device *dev, resource_size_t offset,
-				   resource_size_t size);
 void __iomem *devm_ioremap_nocache(struct device *dev, resource_size_t offset,
 				   resource_size_t size);
 void __iomem *devm_ioremap_wc(struct device *dev, resource_size_t offset,

--- a/lib/devres.c
+++ b/lib/devres.c
@@ -9,7 +9,6 @@
 enum devm_ioremap_type {
 	DEVM_IOREMAP = 0,
 	DEVM_IOREMAP_NC,
-	DEVM_IOREMAP_UC,
 	DEVM_IOREMAP_WC,
 };
 
@@ -40,9 +39,6 @@ static void __iomem *__devm_ioremap(struct device *dev, resource_size_t offset,
 	case DEVM_IOREMAP_NC:
 		addr = ioremap_nocache(offset, size);
 		break;
-	case DEVM_IOREMAP_UC:
-		addr = ioremap_uc(offset, size);
-		break;
 	case DEVM_IOREMAP_WC:
 		addr = ioremap_wc(offset, size);
 		break;
@@ -71,21 +67,6 @@ void __iomem *devm_ioremap(struct device *dev, resource_size_t offset,
 	return __devm_ioremap(dev, offset, size, DEVM_IOREMAP);
 }
 EXPORT_SYMBOL(devm_ioremap);
-
-/**
- * devm_ioremap_uc - Managed ioremap_uc()
- * @dev: Generic device to remap IO address for
- * @offset: Resource address to map
- * @size: Size of map
- *
- * Managed ioremap_uc().  Map is automatically unmapped on driver detach.
- */
-void __iomem *devm_ioremap_uc(struct device *dev, resource_size_t offset,
-			      resource_size_t size)
-{
-	return __devm_ioremap(dev, offset, size, DEVM_IOREMAP_UC);
-}
-EXPORT_SYMBOL_GPL(devm_ioremap_uc);
 
 /**
  * devm_ioremap_nocache - Managed ioremap_nocache()


### PR DESCRIPTION
(The PR title may be misleading due to my English...)
I reverted two commits that were backported by linux-surface, because they're now backported by upstream on v4.19.122.

(Do you think reverting our commits explicitly is needed on devel branch? If not, feel free to close this PR, thanks.)

Note: `ioremap_uc` related patches in v4.19-surface-devel is now only commit de067f5c120969 ("docs: driver-model: add devm_ioremap_uc"), which is not in upstream v4.19 (at least yet?)