### PR TITLE
mwifiex: fix S0ix/AP-scanning after suspend by sw method instead of hw

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/main.c
+++ b/drivers/net/wireless/marvell/mwifiex/main.c
@@ -1469,6 +1469,8 @@ int mwifiex_shutdown_sw(struct mwifiex_adapter *adapter)
 	priv = mwifiex_get_priv(adapter, MWIFIEX_BSS_ROLE_ANY);
 	mwifiex_deauthenticate(priv, NULL);
 
+	mwifiex_init_shutdown_fw(priv, MWIFIEX_FUNC_SHUTDOWN);
+
 	mwifiex_uninit_sw(adapter);
 	adapter->is_up = false;
 

--- a/drivers/net/wireless/marvell/mwifiex/main.c
+++ b/drivers/net/wireless/marvell/mwifiex/main.c
@@ -1453,7 +1453,7 @@ static void mwifiex_uninit_sw(struct mwifiex_adapter *adapter)
 }
 
 /*
- * This function gets called during PCIe function level reset.
+ * This function can be used for shutting down the adapter SW.
  */
 int mwifiex_shutdown_sw(struct mwifiex_adapter *adapter)
 {
@@ -1481,7 +1481,7 @@ int mwifiex_shutdown_sw(struct mwifiex_adapter *adapter)
 }
 EXPORT_SYMBOL_GPL(mwifiex_shutdown_sw);
 
-/* This function gets called during PCIe function level reset. Required
+/* This function can be used for reinitting the adapter SW. Required
  * code is extracted from mwifiex_add_card()
  */
 int

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -145,8 +145,7 @@ static bool mwifiex_pcie_ok_to_access_hw(struct mwifiex_adapter *adapter)
  * registered functions must have drivers with suspend and resume
  * methods. Failing that the kernel simply removes the whole card.
  *
- * If already not suspended, this function allocates and sends a host
- * sleep activate request to the firmware and turns off the traffic.
+ * This function shuts down the adapter.
  */
 static int mwifiex_pcie_suspend(struct device *dev)
 {
@@ -154,31 +153,21 @@ static int mwifiex_pcie_suspend(struct device *dev)
 	struct pcie_service_card *card = dev_get_drvdata(dev);
 
 
-	/* Might still be loading firmware */
-	wait_for_completion(&card->fw_done);
-
 	adapter = card->adapter;
 	if (!adapter) {
 		dev_err(dev, "adapter is not valid\n");
 		return 0;
 	}
 
-	mwifiex_enable_wake(adapter);
-
-	/* Enable the Host Sleep */
-	if (!mwifiex_enable_hs(adapter)) {
+	/* Shut down SW */
+	if (mwifiex_shutdown_sw(adapter)) {
 		mwifiex_dbg(adapter, ERROR,
 			    "cmd: failed to suspend\n");
-		clear_bit(MWIFIEX_IS_HS_ENABLING, &adapter->work_flags);
-		mwifiex_disable_wake(adapter);
 		return -EFAULT;
 	}
 
-	flush_workqueue(adapter->workqueue);
-
 	/* Indicate device suspended */
 	set_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags);
-	clear_bit(MWIFIEX_IS_HS_ENABLING, &adapter->work_flags);
 
 	return 0;
 }
@@ -188,13 +177,13 @@ static int mwifiex_pcie_suspend(struct device *dev)
  * registered functions must have drivers with suspend and resume
  * methods. Failing that the kernel simply removes the whole card.
  *
- * If already not resumed, this function turns on the traffic and
- * sends a host sleep cancel request to the firmware.
+ * If already not resumed, this function reinits the adapter.
  */
 static int mwifiex_pcie_resume(struct device *dev)
 {
 	struct mwifiex_adapter *adapter;
 	struct pcie_service_card *card = dev_get_drvdata(dev);
+	int ret;
 
 
 	if (!card->adapter) {
@@ -212,9 +201,11 @@ static int mwifiex_pcie_resume(struct device *dev)
 
 	clear_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags);
 
-	mwifiex_cancel_hs(mwifiex_get_priv(adapter, MWIFIEX_BSS_ROLE_STA),
-			  MWIFIEX_ASYNC_CMD);
-	mwifiex_disable_wake(adapter);
+	ret = mwifiex_reinit_sw(adapter);
+	if (ret)
+		dev_err(dev, "reinit failed: %d\n", ret);
+	else
+		mwifiex_dbg(adapter, INFO, "%s, successful\n", __func__);
 
 	return 0;
 }

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -147,45 +147,38 @@ static bool mwifiex_pcie_ok_to_access_hw(struct mwifiex_adapter *adapter)
  *
  * If already not suspended, this function allocates and sends a host
  * sleep activate request to the firmware and turns off the traffic.
- *
- * XXX: ignoring all the above comment and just removes the card to
- * fix S0ix and "AP scanning (sometimes) not working after suspend".
- * Required code is extracted from mwifiex_pcie_remove().
  */
 static int mwifiex_pcie_suspend(struct device *dev)
 {
-	struct pci_dev *pdev = to_pci_dev(dev);
-	struct pcie_service_card *card = pci_get_drvdata(pdev);
 	struct mwifiex_adapter *adapter;
-	struct mwifiex_private *priv;
-	const struct mwifiex_pcie_card_reg *reg;
-	u32 fw_status;
-	int ret;
+	struct pcie_service_card *card = dev_get_drvdata(dev);
+
 
 	/* Might still be loading firmware */
 	wait_for_completion(&card->fw_done);
 
 	adapter = card->adapter;
-	if (!adapter || !adapter->priv_num)
+	if (!adapter) {
+		dev_err(dev, "adapter is not valid\n");
 		return 0;
-
-	reg = card->pcie.reg;
-	if (reg)
-		ret = mwifiex_read_reg(adapter, reg->fw_status, &fw_status);
-	else
-		fw_status = -1;
-
-	if (fw_status == FIRMWARE_READY_PCIE && !adapter->mfg_mode) {
-		mwifiex_deauthenticate_all(adapter);
-
-		priv = mwifiex_get_priv(adapter, MWIFIEX_BSS_ROLE_ANY);
-
-		mwifiex_disable_auto_ds(priv);
-
-		mwifiex_init_shutdown_fw(priv, MWIFIEX_FUNC_SHUTDOWN);
 	}
 
-	mwifiex_remove_card(adapter);
+	mwifiex_enable_wake(adapter);
+
+	/* Enable the Host Sleep */
+	if (!mwifiex_enable_hs(adapter)) {
+		mwifiex_dbg(adapter, ERROR,
+			    "cmd: failed to suspend\n");
+		clear_bit(MWIFIEX_IS_HS_ENABLING, &adapter->work_flags);
+		mwifiex_disable_wake(adapter);
+		return -EFAULT;
+	}
+
+	flush_workqueue(adapter->workqueue);
+
+	/* Indicate device suspended */
+	set_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags);
+	clear_bit(MWIFIEX_IS_HS_ENABLING, &adapter->work_flags);
 
 	return 0;
 }
@@ -197,35 +190,31 @@ static int mwifiex_pcie_suspend(struct device *dev)
  *
  * If already not resumed, this function turns on the traffic and
  * sends a host sleep cancel request to the firmware.
- *
- * XXX: ignoring all the above comment and probes the card that was
- * removed on suspend. Required code is extracted from mwifiex_pcie_probe().
  */
 static int mwifiex_pcie_resume(struct device *dev)
 {
-	struct pci_dev *pdev = to_pci_dev(dev);
-	struct pcie_service_card *card = pci_get_drvdata(pdev);
-	int ret;
+	struct mwifiex_adapter *adapter;
+	struct pcie_service_card *card = dev_get_drvdata(dev);
 
-	pr_debug("info: vendor=0x%4.04X device=0x%4.04X rev=%d\n",
-		 pdev->vendor, pdev->device, pdev->revision);
 
-	init_completion(&card->fw_done);
-
-	card->dev = pdev;
-
-	/* device tree node parsing and platform specific configuration */
-	if (pdev->dev.of_node) {
-		ret = mwifiex_pcie_probe_of(&pdev->dev);
-		if (ret)
-			return ret;
+	if (!card->adapter) {
+		dev_err(dev, "adapter structure is not valid\n");
+		return 0;
 	}
 
-	if (mwifiex_add_card(card, &card->fw_done, &pcie_ops,
-			MWIFIEX_PCIE, &pdev->dev)) {
-		pr_err("%s failed\n", __func__);
-		return -1;
+	adapter = card->adapter;
+
+	if (!test_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags)) {
+		mwifiex_dbg(adapter, WARN,
+			    "Device already resumed\n");
+		return 0;
 	}
+
+	clear_bit(MWIFIEX_IS_SUSPENDED, &adapter->work_flags);
+
+	mwifiex_cancel_hs(mwifiex_get_priv(adapter, MWIFIEX_BSS_ROLE_STA),
+			  MWIFIEX_ASYNC_CMD);
+	mwifiex_disable_wake(adapter);
 
 	return 0;
 }


### PR DESCRIPTION
Hi, I've just opened a new branch that tries to fix mwifiex suspend issues in a more simple way.

Issues in upstream mwifiex regarding suspend:
- reportedly breaks S0ix on suspend
- sometimes breaks AP scanning after suspend

The previous patch `mwifiex_pcie: remove()/probe() card on suspend()/resume()` does remove()/probe() card on suspend()/resume(). This may be too aggressive.
The new patch `mwifiex: pcie: use shutdown_sw()/reinit_sw() on suspend()/resume()` tries to fix by instead sw-based way (simpler/milder)

At least I confirmed that AP scanning always works after suspend on SB1.
However, I can't confirm S0ix because SB1 can't achieve S0ix by other unknown issues anyway.

So, first, I want you folks to test if S0ix still works after this PR.
Thanks.

Note that this is not yet for upstreaming (e.g. comment at top of suspend()/resume() functions, debug output, etc.)

EDIT: the second patch `mwifiex: fix mwifiex_shutdown_sw() causing sw reset failure` is required for the main part of this PR (`mwifiex: pcie: use shutdown_sw()/reinit_sw() on suspend()/resume()`)