### PR TITLE
(rework) mwifiex: pcie: skip cancel_work_sync() on reset failure path

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/main.h
+++ b/drivers/net/wireless/marvell/mwifiex/main.h
@@ -1054,9 +1054,6 @@ struct mwifiex_adapter {
 	void *devdump_data;
 	int devdump_len;
 	struct timer_list devdump_timer;
-
-	/* Indicates a reset is ongoing or not */
-	bool pci_reset_ongoing;
 };
 
 void mwifiex_process_tx_queue(struct mwifiex_adapter *adapter);

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -393,6 +393,8 @@ static void mwifiex_pcie_reset_prepare(struct pci_dev *pdev)
 	clear_bit(MWIFIEX_IFACE_WORK_DEVICE_DUMP, &card->work_flags);
 	clear_bit(MWIFIEX_IFACE_WORK_CARD_RESET, &card->work_flags);
 	mwifiex_dbg(adapter, INFO, "%s, successful\n", __func__);
+
+	card->pci_reset_ongoing = true;
 }
 
 /*
@@ -421,6 +423,8 @@ static void mwifiex_pcie_reset_done(struct pci_dev *pdev)
 		dev_err(&pdev->dev, "reinit failed: %d\n", ret);
 	else
 		mwifiex_dbg(adapter, INFO, "%s, successful\n", __func__);
+
+	card->pci_reset_ongoing = false;
 }
 
 static const struct pci_error_handlers mwifiex_pcie_err_handler = {
@@ -3011,7 +3015,19 @@ static void mwifiex_cleanup_pcie(struct mwifiex_adapter *adapter)
 	int ret;
 	u32 fw_status;
 
-	cancel_work_sync(&card->work);
+	/* Perform the cancel_work_sync() only when we're not resetting
+	 * the card. It's because that function never returns if we're
+	 * in reset path. If we're here when resetting the card, it means
+	 * that we failed to reset the card (reset failure path).
+	 */
+	if (!card->pci_reset_ongoing) {
+		mwifiex_dbg(adapter, MSG, "performing cancel_work_sync()...\n");
+		cancel_work_sync(&card->work);
+		mwifiex_dbg(adapter, MSG, "cancel_work_sync() done\n");
+	} else {
+		mwifiex_dbg(adapter, MSG,
+			    "skipped cancel_work_sync() because we're in card reset failure path\n");
+	}
 
 	ret = mwifiex_read_reg(adapter, reg->fw_status, &fw_status);
 	if (fw_status == FIRMWARE_READY_PCIE) {

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -393,8 +393,6 @@ static void mwifiex_pcie_reset_prepare(struct pci_dev *pdev)
 	clear_bit(MWIFIEX_IFACE_WORK_DEVICE_DUMP, &card->work_flags);
 	clear_bit(MWIFIEX_IFACE_WORK_CARD_RESET, &card->work_flags);
 	mwifiex_dbg(adapter, INFO, "%s, successful\n", __func__);
-
-	adapter->pci_reset_ongoing = true;
 }
 
 /*
@@ -423,8 +421,6 @@ static void mwifiex_pcie_reset_done(struct pci_dev *pdev)
 		dev_err(&pdev->dev, "reinit failed: %d\n", ret);
 	else
 		mwifiex_dbg(adapter, INFO, "%s, successful\n", __func__);
-
-	adapter->pci_reset_ongoing = false;
 }
 
 static const struct pci_error_handlers mwifiex_pcie_err_handler = {
@@ -3015,19 +3011,7 @@ static void mwifiex_cleanup_pcie(struct mwifiex_adapter *adapter)
 	int ret;
 	u32 fw_status;
 
-	/* Perform the cancel_work_sync() only when we're not resetting
-	 * the card. It's because that function never returns if we're
-	 * in reset path. If we're here when resetting the card, it means
-	 * that we failed to reset the card (reset failure path).
-	 */
-	if (!adapter->pci_reset_ongoing) {
-		mwifiex_dbg(adapter, MSG, "performing cancel_work_sync()...\n");
-		cancel_work_sync(&card->work);
-		mwifiex_dbg(adapter, MSG, "cancel_work_sync() done\n");
-	} else {
-		mwifiex_dbg(adapter, MSG,
-			    "skipped cancel_work_sync() because we're in card reset failure path\n");
-	}
+	cancel_work_sync(&card->work);
 
 	ret = mwifiex_read_reg(adapter, reg->fw_status, &fw_status);
 	if (fw_status == FIRMWARE_READY_PCIE) {

--- a/drivers/net/wireless/marvell/mwifiex/pcie.h
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.h
@@ -391,6 +391,8 @@ struct pcie_service_card {
 	struct mwifiex_msix_context share_irq_ctx;
 	struct work_struct work;
 	unsigned long work_flags;
+
+	bool pci_reset_ongoing;
 };
 
 static inline int


### PR DESCRIPTION
Hi, this PR is a successor of the previous PR (https://github.com/linux-surface/kernel/pull/57).

This PR
1. reverts previous patch
2. adds updated patch which addressed issues with the previous PR.

The new patch addressed the following:
- Placed `pci_reset_ongoing` variable into `pcie_service_card` (`card->pci_reset_ongoing`) instead of `mwifiex_adapter` (`adapter->pci_reset_ongoing`) (https://github.com/linux-surface/kernel/pull/57#discussion_r495454923)
- Added commit message for why the deadlock happens when reset failed (https://github.com/linux-surface/kernel/pull/57#issuecomment-699493455)