### PR TITLE
Revert "mwifiex: sta_cmd: do not enable auto_ds by default"

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2247,6 +2247,7 @@ int mwifiex_sta_prepare_cmd(struct mwifiex_private *priv, uint16_t cmd_no,
  *      - Function init (for first interface only)
  *      - Read MAC address (for first interface only)
  *      - Reconfigure Tx buffer size (for first interface only)
+ *      - Enable auto deep sleep (for first interface only)
  *      - Get Tx rate
  *      - Get Tx power
  *      - Set IBSS coalescing status
@@ -2259,6 +2260,7 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 	struct mwifiex_adapter *adapter = priv->adapter;
 	int ret;
 	struct mwifiex_ds_11n_amsdu_aggr_ctrl amsdu_aggr_ctrl;
+	struct mwifiex_ds_auto_ds auto_ds;
 	enum state_11d_t state_11d;
 	struct mwifiex_ds_11n_tx_cfg tx_cfg;
 	u8 sdio_sp_rx_aggr_enable;
@@ -2380,10 +2382,17 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 	if (ret)
 		return -1;
 
-	/* Not enabling auto deep sleep (auto_ds) by default. Enabling
-	 * this reportedly causes "suspend/resume fails when not connected
-	 * to an Access Point." Therefore, the relevant code was removed
-	 * from here. */
+	if (!disable_auto_ds && first_sta &&
+	    priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
+		/* Enable auto deep sleep */
+		auto_ds.auto_ds = DEEP_SLEEP_ON;
+		auto_ds.idle_time = DEEP_SLEEP_IDLE_TIME;
+		ret = mwifiex_send_cmd(priv, HostCmd_CMD_802_11_PS_MODE_ENH,
+				       EN_AUTO_PS, BITMAP_AUTO_DS,
+				       &auto_ds, true);
+		if (ret)
+			return -1;
+	}
 
 	if (priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
 		/* Send cmd to FW to enable/disable 11D function */


### PR DESCRIPTION
This reverts commit ef0b1af221ff57f698a303f7e332951a0052fbc3.

Reason for revert:
  It seems that auto_ds won't affect stability. Let's re-enable auto_ds
  and see what happens.

Signed-off-by: Tsuchiya Yuto <kitakar@gmail.com>