### PR TITLE
mwifiex: rebase some patches

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
@@ -25,6 +25,11 @@
 static char *reg_alpha2;
 module_param(reg_alpha2, charp, 0);
 
+static bool allow_ps_mode;
+module_param(allow_ps_mode, bool, 0644);
+MODULE_PARM_DESC(allow_ps_mode,
+		 "allow WiFi power management to be enabled. (default: disallowed)");
+
 static const struct ieee80211_iface_limit mwifiex_ap_sta_limits[] = {
 	{
 		.max = 3, .types = BIT(NL80211_IFTYPE_STATION) |
@@ -433,6 +438,17 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
 			    "info: ignore timeout value for IEEE Power Save\n");
 
 	ps_mode = enabled;
+
+	/* Allow ps_mode to be enabled only when allow_ps_mode is true */
+	if (ps_mode && !allow_ps_mode) {
+		mwifiex_dbg(priv->adapter, MSG,
+			    "Enabling ps_mode disallowed by modparam\n");
+
+		/* Return -EPERM to inform userspace tools that setting
+		 * power_save to be enabled is not permitted.
+		 */
+		return -EPERM;
+	}
 
 	return mwifiex_drv_set_power(priv, &ps_mode);
 }

--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
@@ -450,6 +450,13 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
 		return -EPERM;
 	}
 
+	if (ps_mode)
+		mwifiex_dbg(priv->adapter, MSG,
+			    "Enabling ps_mode, disable if unstable.\n");
+	else
+		mwifiex_dbg(priv->adapter, MSG,
+			    "Disabling ps_mode.\n");
+
 	return mwifiex_drv_set_power(priv, &ps_mode);
 }
 

--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
@@ -25,11 +25,6 @@
 static char *reg_alpha2;
 module_param(reg_alpha2, charp, 0);
 
-static bool allow_ps_mode;
-module_param(allow_ps_mode, bool, 0444);
-MODULE_PARM_DESC(allow_ps_mode,
-		 "allow WiFi power management to be enabled. (default: disallowed)");
-
 static const struct ieee80211_iface_limit mwifiex_ap_sta_limits[] = {
 	{
 		.max = 3, .types = BIT(NL80211_IFTYPE_STATION) |
@@ -438,19 +433,6 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
 			    "info: ignore timeout value for IEEE Power Save\n");
 
 	ps_mode = enabled;
-
-	/* Allow ps_mode to be enabled only when allow_ps_mode is set
-	 * (but always allow ps_mode to be disabled in case it gets enabled
-	 * for unknown reason and you want to disable it) */
-	if (ps_mode && !allow_ps_mode) {
-		dev_info(priv->adapter->dev,
-			    "Request to enable ps_mode received but it's disallowed "
-			    "by module parameter. Rejecting the request.\n");
-
-		/* Return negative value to inform userspace tools that setting
-		 * power_save to be enabled is not permitted. */
-		return -1;
-	}
 
 	return mwifiex_drv_set_power(priv, &ps_mode);
 }

--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
@@ -452,14 +452,6 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
 		return -1;
 	}
 
-	if (ps_mode)
-		dev_warn(priv->adapter->dev,
-			    "WARN: Request to enable ps_mode received. Enabling it. "
-			    "Disable it if you encounter connection instability.\n");
-	else
-		dev_info(priv->adapter->dev,
-			    "Request to disable ps_mode received. Disabling it.\n");
-
 	return mwifiex_drv_set_power(priv, &ps_mode);
 }
 

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -226,6 +226,7 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
 					const struct pci_device_id *ent)
 {
 	struct pcie_service_card *card;
+	struct pci_dev *parent_pdev = pci_upstream_bridge(pdev);
 	int ret;
 
 	pr_debug("info: vendor=0x%4.04X device=0x%4.04X rev=%d\n",
@@ -266,6 +267,12 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
 		pr_err("%s failed\n", __func__);
 		return -1;
 	}
+
+	/* disable bridge_d3 for Surface gen4+ devices to fix fw crashing
+	 * after suspend
+	 */
+	if (card->quirks & QUIRK_NO_BRIDGE_D3)
+		parent_pdev->bridge_d3 = false;
 
 	return 0;
 }

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -226,12 +226,7 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
 					const struct pci_device_id *ent)
 {
 	struct pcie_service_card *card;
-	struct pci_dev *parent_pdev = pci_upstream_bridge(pdev);
 	int ret;
-
-	/* disable bridge_d3 to fix driver crashing after suspend on gen4+
-	 * Surface devices */
-	parent_pdev->bridge_d3 = false;
 
 	pr_debug("info: vendor=0x%4.04X device=0x%4.04X rev=%d\n",
 		 pdev->vendor, pdev->device, pdev->revision);

--- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
@@ -32,7 +32,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Pro 4"),
 		},
-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
+		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+					QUIRK_NO_BRIDGE_D3),
 	},
 	{
 		.ident = "Surface Pro 5",
@@ -41,7 +42,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "Surface_Pro_1796"),
 		},
-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
+		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+					QUIRK_NO_BRIDGE_D3),
 	},
 	{
 		.ident = "Surface Pro 5 (LTE)",
@@ -50,7 +52,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "Surface_Pro_1807"),
 		},
-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
+		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+					QUIRK_NO_BRIDGE_D3),
 	},
 	{
 		.ident = "Surface Pro 6",
@@ -58,7 +61,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Pro 6"),
 		},
-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
+		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+					QUIRK_NO_BRIDGE_D3),
 	},
 	{
 		.ident = "Surface Book 1",
@@ -66,7 +70,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Book"),
 		},
-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
+		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+					QUIRK_NO_BRIDGE_D3),
 	},
 	{
 		.ident = "Surface Book 2",
@@ -74,7 +79,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Book 2"),
 		},
-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
+		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+					QUIRK_NO_BRIDGE_D3),
 	},
 	{
 		.ident = "Surface Laptop 1",
@@ -82,7 +88,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Laptop"),
 		},
-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
+		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+					QUIRK_NO_BRIDGE_D3),
 	},
 	{
 		.ident = "Surface Laptop 2",
@@ -90,7 +97,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Laptop 2"),
 		},
-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
+		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+					QUIRK_NO_BRIDGE_D3),
 	},
 	{
 		.ident = "Surface 3",
@@ -136,6 +144,9 @@ void mwifiex_initialize_quirks(struct pcie_service_card *card)
 	if (card->quirks & QUIRK_FW_RST_WSID_S3)
 		dev_info(&pdev->dev,
 			 "quirk reset_wsid for Surface 3 enabled\n");
+	if (card->quirks & QUIRK_NO_BRIDGE_D3)
+		dev_info(&pdev->dev,
+			 "quirk no_brigde_d3 enabled\n");
 }
 
 static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)

--- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
+++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
@@ -11,6 +11,7 @@
  * be handled differently. Currently, only S3 is supported.
  */
 #define QUIRK_FW_RST_WSID_S3	BIT(1)
+#define QUIRK_NO_BRIDGE_D3	BIT(2)
 
 void mwifiex_initialize_quirks(struct pcie_service_card *card);
 int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);

--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2333,12 +2333,17 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 			return -1;
 
 		if (priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
-			/* Enable IEEE PS by default */
-			priv->adapter->ps_mode = MWIFIEX_802_11_POWER_MODE_PSP;
+			/* Disable IEEE PS by default */
+			priv->adapter->ps_mode = MWIFIEX_802_11_POWER_MODE_CAM;
 			ret = mwifiex_send_cmd(priv,
 					       HostCmd_CMD_802_11_PS_MODE_ENH,
-					       EN_AUTO_PS, BITMAP_STA_PS, NULL,
+					       DIS_AUTO_PS, BITMAP_STA_PS, NULL,
 					       true);
+			if (ret)
+				return -1;
+			ret = mwifiex_send_cmd(priv,
+					       HostCmd_CMD_802_11_PS_MODE_ENH,
+					       GET_PS, 0, NULL, false);
 			if (ret)
 				return -1;
 		}

--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2332,11 +2332,6 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 		if (ret)
 			return -1;
 
-		/* Not enabling ps_mode (IEEE power_save) by default. Enabling
-		 * this causes connection instability, especially on 5GHz APs
-		 * and eventually causes "firmware wakeup failed". Therefore,
-		 * the relevant code was removed from here. */
-
 		if (drcs) {
 			adapter->drcs_enabled = true;
 			if (ISSUPP_DRCS_ENABLED(adapter->fw_cap_info))

--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2332,6 +2332,17 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 		if (ret)
 			return -1;
 
+		if (priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
+			/* Enable IEEE PS by default */
+			priv->adapter->ps_mode = MWIFIEX_802_11_POWER_MODE_PSP;
+			ret = mwifiex_send_cmd(priv,
+					       HostCmd_CMD_802_11_PS_MODE_ENH,
+					       EN_AUTO_PS, BITMAP_STA_PS, NULL,
+					       true);
+			if (ret)
+				return -1;
+		}
+
 		if (drcs) {
 			adapter->drcs_enabled = true;
 			if (ISSUPP_DRCS_ENABLED(adapter->fw_cap_info))


### PR DESCRIPTION
Hi, I slightly cleaned up mwifiex patches.

1. revert some existing patches to improve changes and commit messages
2. added improved patches


`mwifiex: pcie: disable bridge_d3 for Surface gen4+`
Changes from the previous patch:
- Use recently added quirk implementation and apply for only Surface gen4+ devices
- Moved to the bottom of probe() so that quirk implementation can init before use

`mwifiex: add allow_ps_mode module parameter`
Changes from the previous patch:
- Use `-EPERM` instead of `-1` for return value when enabling ps_mode is disallowed by modparam
- changed `allow_ps_mode` modparam permission from `0444` to `0644` because it can be changed after probe as well
- Simplified comment in code
- Simplified print message

`mwifiex: mwifiex: print message when changing ps_mode`
Changes from the previous patch:
- Simplified print messages

`mwifiex: disable ps_mode explicitly by default instead`
Changes from previous patch:
- Squashed `mwifiex: sta_cmd: add comment for not enabling ps_mode by default` and `mwifiex: sta_cmd: do not enable ps_mode by default`
- Disable ps_mode explicitly instead of just removing the code

Removing the code that enables ps_mode might be enough, but there's also
no reason not to explicitly disable it. So, let's disable it explicitly.
