### PR TITLE
ov5693: Add user controls to flip image

### DIFF
--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -136,6 +136,13 @@
 #define OV5693_MWB_BLUE_GAIN_H			0x3404
 #define OV5693_MWB_GAIN_MAX			0x0fff
 
+#define OV5693_TIMING_REG21             0x3821 /* horizontal flip */
+#define OV5693_TIMING_REG21_NORMAL      0x18
+#define OV5693_TIMING_REG21_FLIP        0x1E
+#define OV5693_TIMING_REG20             0x3820 /* vertical flip */
+#define OV5693_TIMING_REG20_NORMAL      0x10
+#define OV5693_TIMING_REG20_FLIP        0x16
+
 #define OV5693_START_STREAMING			0x01
 #define OV5693_STOP_STREAMING			0x00
 
@@ -260,6 +267,9 @@ struct ov5693_device {
 	u8 type;
 	bool vcm_update;
 	enum vcm_type vcm;
+
+	bool hflip;
+	bool vflip;
 
 	bool has_vcm;
 };


### PR DESCRIPTION
Add V4L2_CID_HFLIP and V4L2_CID_VFLIP to support flipping the image on the sensor side.

I added some simple test cases to the ipu3 pipeline in libcamera and the image does change direction (tested on SB2). A full implementation for the ipu3 pipeline will follow later.