### PR TITLE
ipu3: Image rotation support

### DIFF
--- a/drivers/media/pci/intel/ipu3/cio2-bridge.h
+++ b/drivers/media/pci/intel/ipu3/cio2-bridge.h
@@ -12,6 +12,19 @@
 #define CIO2_MAX_LANES				4
 #define MAX_NUM_LINK_FREQS			3
 
+/* Values are estimated guesses as we don't have a spec */
+#define CIO2_SENSOR_ROTATION_NORMAL		0
+#define CIO2_SENSOR_ROTATION_INVERTED		1
+
+/* Panel position defined in _PLD section of ACPI Specification 6.3 */
+#define CIO2_PLD_PANEL_TOP			0
+#define CIO2_PLD_PANEL_BOTTOM			1
+#define CIO2_PLD_PANEL_LEFT			2
+#define CIO2_PLD_PANEL_RIGHT			3
+#define CIO2_PLD_PANEL_FRONT			4
+#define CIO2_PLD_PANEL_BACK			5
+#define CIO2_PLD_PANEL_UNKNOWN			6
+
 #define CIO2_SENSOR_CONFIG(_HID, _NR, ...)	\
 	(const struct cio2_sensor_config) {	\
 		.hid = _HID,			\

--- a/drivers/media/pci/intel/ipu3/cio2-bridge.h
+++ b/drivers/media/pci/intel/ipu3/cio2-bridge.h
@@ -80,6 +80,7 @@ struct cio2_sensor_ssdb {
 struct cio2_property_names {
 	char clock_frequency[16];
 	char rotation[9];
+	char orientation[12];
 	char bus_type[9];
 	char data_lanes[11];
 	char remote_endpoint[16];
@@ -106,6 +107,8 @@ struct cio2_sensor {
 	struct cio2_node_names node_names;
 
 	struct cio2_sensor_ssdb ssdb;
+	struct acpi_pld_info *pld;
+
 	struct cio2_property_names prop_names;
 	struct property_entry ep_properties[5];
 	struct property_entry dev_properties[3];


### PR DESCRIPTION
This PR adds rotation/orientation support for cio2-bridge and ov5693.

The cio2-bridge parses the sensor orientation and rotation from the ACPI buffers and expose them as fwnodes. The ov5693 reads the values from the fwnodes and create the controls. Then libcamera picks up the controls and rotate the image in the pipeline. 

To test the whole thing you need this PR and you have to apply this [patch](https://patchwork.libcamera.org/patch/10957/) to libcamera.

Does anyone have a better idea for [this part](https://github.com/fabwu/linux-surface-kernel/commit/3c644c43e4860cacec1d8523728f3373a9fbc5fb#diff-99ed78a9282d84363094cde07371167771226cd506695acab79c3f42044db146R76-R94)? Converting the values like that feels a bit ugly...
