### PR TITLE
Sync with IPTS module repo

### DIFF
--- a/drivers/misc/ipts/context.h
+++ b/drivers/misc/ipts/context.h
@@ -45,4 +45,3 @@ struct ipts_context {
 };
 
 #endif /* _IPTS_CONTEXT_H_ */
-

--- a/drivers/misc/ipts/control.c
+++ b/drivers/misc/ipts/control.c
@@ -13,8 +13,8 @@
 #include "resources.h"
 #include "uapi.h"
 
-int ipts_control_send(struct ipts_context *ipts,
-		u32 code, void *payload, size_t size)
+int ipts_control_send(struct ipts_context *ipts, u32 code, void *payload,
+		      size_t size)
 {
 	int ret;
 	struct ipts_command cmd;
@@ -74,4 +74,3 @@ int ipts_control_restart(struct ipts_context *ipts)
 	ipts->restart = true;
 	return ipts_control_stop(ipts);
 }
-

--- a/drivers/misc/ipts/control.c
+++ b/drivers/misc/ipts/control.c
@@ -59,6 +59,10 @@ int ipts_control_stop(struct ipts_context *ipts)
 
 	ipts_uapi_unlink();
 	ipts_resources_free(ipts);
+
+	if (!mei_cldev_enabled(ipts->cldev))
+		return 0;
+
 	return ipts_control_send(ipts, IPTS_CMD_CLEAR_MEM_WINDOW, NULL, 0);
 }
 

--- a/drivers/misc/ipts/control.h
+++ b/drivers/misc/ipts/control.h
@@ -13,11 +13,10 @@
 
 #include "context.h"
 
-int ipts_control_send(struct ipts_context *ipts,
-		u32 cmd, void *payload, size_t size);
+int ipts_control_send(struct ipts_context *ipts, u32 cmd, void *payload,
+		      size_t size);
 int ipts_control_start(struct ipts_context *ipts);
 int ipts_control_restart(struct ipts_context *ipts);
 int ipts_control_stop(struct ipts_context *ipts);
 
 #endif /* _IPTS_CONTROL_H_ */
-

--- a/drivers/misc/ipts/mei.c
+++ b/drivers/misc/ipts/mei.c
@@ -31,7 +31,7 @@ static int ipts_mei_set_dma_mask(struct mei_cl_device *cldev)
 }
 
 static int ipts_mei_probe(struct mei_cl_device *cldev,
-		const struct mei_cl_device_id *id)
+			  const struct mei_cl_device_id *id)
 {
 	int ret;
 	struct ipts_context *ipts;
@@ -47,7 +47,7 @@ static int ipts_mei_probe(struct mei_cl_device *cldev,
 		return ret;
 	}
 
-	ipts = kzalloc(sizeof(struct ipts_context), GFP_KERNEL);
+	ipts = kzalloc(sizeof(*ipts), GFP_KERNEL);
 	if (!ipts) {
 		mei_cldev_disable(cldev);
 		return -ENOMEM;
@@ -76,7 +76,7 @@ static int ipts_mei_remove(struct mei_cl_device *cldev)
 
 static struct mei_cl_device_id ipts_mei_device_id_table[] = {
 	{ "", IPTS_MEI_UUID, MEI_CL_VERSION_ANY },
-	{ },
+	{},
 };
 MODULE_DEVICE_TABLE(mei, ipts_mei_device_id_table);
 
@@ -116,4 +116,3 @@ MODULE_LICENSE("GPL");
 
 module_init(ipts_mei_init);
 module_exit(ipts_mei_exit);
-

--- a/drivers/misc/ipts/mei.c
+++ b/drivers/misc/ipts/mei.c
@@ -65,19 +65,10 @@ static int ipts_mei_probe(struct mei_cl_device *cldev,
 
 static int ipts_mei_remove(struct mei_cl_device *cldev)
 {
-	int i;
 	struct ipts_context *ipts = mei_cldev_get_drvdata(cldev);
 
-	ipts_control_stop(ipts);
-
-	for (i = 0; i < 20; i++) {
-		if (ipts->status == IPTS_HOST_STATUS_STOPPED)
-			break;
-
-		msleep(25);
-	}
-
 	mei_cldev_disable(cldev);
+	ipts_control_stop(ipts);
 	kfree(ipts);
 
 	return 0;

--- a/drivers/misc/ipts/protocol.h
+++ b/drivers/misc/ipts/protocol.h
@@ -74,6 +74,15 @@
 #define IPTS_CMD_CLEAR_MEM_WINDOW 0x00000007
 #define IPTS_RSP_CLEAR_MEM_WINDOW 0x80000007
 
+/*
+ * Instructs the ME to reset the touch sensor.
+ *
+ * The command must contain struct ipts_reset_sensor_cmd as payload.
+ * The response will not contain any payload.
+ */
+#define IPTS_CMD_RESET_SENSOR 0x0000000B
+#define IPTS_RSP_RESET_SENSOR 0x8000000B
+
 /**
  * enum ipts_status - Possible status codes returned by IPTS commands.
  * @IPTS_STATUS_SUCCESS:                 Operation completed successfully.
@@ -206,6 +215,25 @@ struct ipts_set_mem_window_cmd {
 struct ipts_feedback_cmd {
 	u32 buffer;
 	u8 reserved[12];
+} __packed;
+
+/**
+ * enum ipts_reset_type - Possible ways of resetting the touch sensor
+ * @IPTS_RESET_TYPE_HARD: Perform hardware reset using GPIO pin.
+ * @IPTS_RESET_TYPE_SOFT: Perform software reset using SPI interface.
+ */
+enum ipts_reset_type {
+	IPTS_RESET_TYPE_HARD = 0,
+	IPTS_RESET_TYPE_SOFT = 1,
+};
+
+/**
+ * struct ipts_reset_sensor_cmd - Payload for the RESET_SENSOR command.
+ * @type: What type of reset should be performed.
+ */
+struct ipts_reset_sensor_cmd {
+	enum ipts_reset_type type;
+	u8 reserved[4];
 } __packed;
 
 /**

--- a/drivers/misc/ipts/protocol.h
+++ b/drivers/misc/ipts/protocol.h
@@ -14,8 +14,9 @@
 /*
  * The MEI client ID for IPTS functionality.
  */
-#define IPTS_MEI_UUID UUID_LE(0x3e8d0870, 0x271a, 0x4208, \
-		0x8e, 0xb5, 0x9a, 0xcb, 0x94, 0x02, 0xae, 0x04)
+#define IPTS_MEI_UUID                                                          \
+	UUID_LE(0x3e8d0870, 0x271a, 0x4208, 0x8e, 0xb5, 0x9a, 0xcb, 0x94,      \
+		0x02, 0xae, 0x04)
 
 /*
  * Queries the device for vendor specific information.
@@ -153,7 +154,7 @@ struct ipts_set_mode_cmd {
 	u8 reserved[12];
 } __packed;
 
-#define IPTS_WORKQUEUE_SIZE      8192
+#define IPTS_WORKQUEUE_SIZE	 8192
 #define IPTS_WORKQUEUE_ITEM_SIZE 16
 
 /**

--- a/drivers/misc/ipts/protocol.h
+++ b/drivers/misc/ipts/protocol.h
@@ -73,150 +73,91 @@
 #define IPTS_CMD_CLEAR_MEM_WINDOW 0x00000007
 #define IPTS_RSP_CLEAR_MEM_WINDOW 0x80000007
 
-/*
- * Singletouch mode is a fallback that does not support
- * a stylus or more than one touch input. The data is
- * received as a HID report with report ID 64.
+/**
+ * enum ipts_status - Possible status codes returned by IPTS commands.
+ * @IPTS_STATUS_SUCCESS:                 Operation completed successfully.
+ * @IPTS_STATUS_INVALID_PARAMS:          Command contained a payload with invalid parameters.
+ * @IPTS_STATUS_ACCESS_DENIED:           ME could not validate buffer addresses supplied by host.
+ * @IPTS_STATUS_CMD_SIZE_ERROR:          Command contains an invalid payload.
+ * @IPTS_STATUS_NOT_READY:               Buffer addresses have not been set.
+ * @IPTS_STATUS_REQUEST_OUTSTANDING:     There is an outstanding command of the same type.
+ *                                       The host must wait for a response before sending another
+ *                                       command of the same type.
+ * @IPTS_STATUS_NO_SENSOR_FOUND:         No sensor could be found. Either no sensor is connected, it
+ *                                       has not been initialized yet, or the system is improperly
+ *                                       configured.
+ * @IPTS_STATUS_OUT_OF_MEMORY:           Not enough free memory for requested operation.
+ * @IPTS_STATUS_INTERNAL_ERROR:          An unexpected error occurred.
+ * @IPTS_STATUS_SENSOR_DISABLED:         The sensor has been disabled and must be reinitialized.
+ * @IPTS_STATUS_COMPAT_CHECK_FAIL:       Compatibility revision check between sensor and ME failed.
+ *                                       The host can ignore this error and attempt to continue.
+ * @IPTS_STATUS_SENSOR_EXPECTED_RESET:   The sensor went through a reset initiated by ME or host.
+ * @IPTS_STATUS_SENSOR_UNEXPECTED_RESET: The sensor went through an unexpected reset.
+ * @IPTS_STATUS_RESET_FAILED:            Requested sensor reset failed to complete.
+ * @IPTS_STATUS_TIMEOUT:                 The operation timed out.
+ * @IPTS_STATUS_TEST_MODE_FAIL:          Test mode pattern did not match expected values.
+ * @IPTS_STATUS_SENSOR_FAIL_FATAL:       The sensor reported a fatal error during reset sequence.
+ *                                       Further progress is not possible.
+ * @IPTS_STATUS_SENSOR_FAIL_NONFATAL:    The sensor reported a fatal error during reset sequence.
+ *                                       The host can attempt to continue.
+ * @IPTS_STATUS_INVALID_DEVICE_CAPS:     The device reported invalid capabilities.
+ * @IPTS_STATUS_QUIESCE_IO_IN_PROGRESS:  Command cannot be completed until Quiesce IO is done.
  */
-#define IPTS_MODE_SINGLETOUCH 0x0
-
-/*
- * Multitouch mode is the "proper" operation mode for IPTS. It will
- * return stylus data as well as capacitive heatmap touch data.
- * This data needs to be processed in userspace before it can be used.
- */
-#define IPTS_MODE_MULTITOUCH 0x1
-
-/*
- * Operation completed successfully.
- */
-#define IPTS_STATUS_SUCCESS 0x0
-
-/*
- * Command contained a payload with invalid parameters.
- */
-#define IPTS_STATUS_INVALID_PARAMS 0x1
-
-/*
- * ME was unable to validate buffer addresses supplied by the host.
- */
-#define IPTS_STATUS_ACCESS_DENIED 0x2
-
-/*
- * Command contained a payload with an invalid size.
- */
-#define IPTS_STATUS_CMD_SIZE_ERROR 0x3
-
-/*
- * Buffer addresses have not been set, or the
- * device is not ready for operation yet.
- */
-#define IPTS_STATUS_NOT_READY 0x4
-
-/*
- * There is an outstanding command of the same type. The host must
- * wait for a response before sending another command of the same type.
- */
-#define IPTS_STATUS_REQUEST_OUTSTANDING 0x5
-
-/*
- * No sensor could be found. Either no sensor is connected, it has not
- * been initialized yet, or the system is improperly configured.
- */
-#define IPTS_STATUS_NO_SENSOR_FOUND 0x6
-
-/*
- * Not enough free memory for requested operation.
- */
-#define IPTS_STATUS_OUT_OF_MEMORY 0x7
-
-/*
- * An unexpected error occured.
- */
-#define IPTS_STATUS_INTERNAL_ERROR 0x8
-
-/*
- * The sensor has been disabled / reset and must be reinitialized.
- */
-#define IPTS_STATUS_SENSOR_DISABLED 0x9
-
-/*
- * Compatibility revision check between sensor and ME failed.
- * The host can ignore this error and attempt to continue.
- */
-#define IPTS_STATUS_COMPAT_CHECK_FAIL 0xA
-
-/*
- * The sensor went through a reset initiated by the ME / the host.
- */
-#define IPTS_STATUS_SENSOR_EXPECTED_RESET 0xB
-
-/*
- * The sensor went through an unexpected reset.
- */
-#define IPTS_STATUS_SENSOR_UNEXPECTED_RESET 0xC
-
-/*
- * Requested sensor reset failed to complete.
- */
-#define IPTS_STATUS_RESET_FAILED 0xD
-
-/*
- * The operation timed out.
- */
-#define IPTS_STATUS_TIMEOUT 0xE
-
-/*
- * Test mode pattern did not match expected values.
- */
-#define IPTS_STATUS_TEST_MODE_FAIL 0xF
-
-/*
- * The sensor reported fatal error during reset sequence.
- * Futher progress is not possible.
- */
-#define IPTS_STATUS_SENSOR_FAIL_FATAL 0x10
-
-/*
- * The sensor reported fatal error during reset sequence.
- * The host can attempt to continue.
- */
-#define IPTS_STATUS_SENSOR_FAIL_NONFATAL 0x11
-
-/*
- * The sensor reported invalid capabilities.
- */
-#define IPTS_STATUS_INVALID_DEVICE_CAPS 0x12
-
-/*
- * The command cannot be completed until Quiesce IO flow has completed.
- */
-#define IPTS_STATUS_QUIESCE_IO_IN_PROGRESS 0x13
+enum ipts_status {
+	IPTS_STATUS_SUCCESS = 0,
+	IPTS_STATUS_INVALID_PARAMS = 1,
+	IPTS_STATUS_ACCESS_DENIED = 2,
+	IPTS_STATUS_CMD_SIZE_ERROR = 3,
+	IPTS_STATUS_NOT_READY = 4,
+	IPTS_STATUS_REQUEST_OUTSTANDING = 5,
+	IPTS_STATUS_NO_SENSOR_FOUND = 6,
+	IPTS_STATUS_OUT_OF_MEMORY = 7,
+	IPTS_STATUS_INTERNAL_ERROR = 8,
+	IPTS_STATUS_SENSOR_DISABLED = 9,
+	IPTS_STATUS_COMPAT_CHECK_FAIL = 10,
+	IPTS_STATUS_SENSOR_EXPECTED_RESET = 11,
+	IPTS_STATUS_SENSOR_UNEXPECTED_RESET = 12,
+	IPTS_STATUS_RESET_FAILED = 13,
+	IPTS_STATUS_TIMEOUT = 14,
+	IPTS_STATUS_TEST_MODE_FAIL = 15,
+	IPTS_STATUS_SENSOR_FAIL_FATAL = 16,
+	IPTS_STATUS_SENSOR_FAIL_NONFATAL = 17,
+	IPTS_STATUS_INVALID_DEVICE_CAPS = 18,
+	IPTS_STATUS_QUIESCE_IO_IN_PROGRESS = 19,
+};
 
 /*
  * The amount of buffers that is used for IPTS
  */
 #define IPTS_BUFFERS 16
 
-#define IPTS_WORKQUEUE_SIZE 8192
-#define IPTS_WORKQUEUE_ITEM_SIZE 16
+/**
+ * enum ipts_mode - Operation mode for IPTS hardware
+ * @IPTS_MODE_SINGLETOUCH: Fallback that supports only one finger and no stylus.
+ *                         The data is received as a HID report with ID 64.
+ * @IPTS_MODE_MULTITOUCH:  The "proper" operation mode for IPTS. It will return
+ *                         stylus data as well as capacitive heatmap touch data.
+ *                         This data needs to be processed in userspace.
+ */
+enum ipts_mode {
+	IPTS_MODE_SINGLETOUCH = 0,
+	IPTS_MODE_MULTITOUCH = 1,
+};
 
 /**
  * struct ipts_set_mode_cmd - Payload for the SET_MODE command.
- *
- * @mode: The mode that IPTS should operate in. (IPTS_MODE_*)
- *
- * This driver only supports multitouch mode. Singletouch mode
- * requires a different control flow that is not implemented.
+ * @mode: The mode that IPTS should operate in.
  */
 struct ipts_set_mode_cmd {
-	u32 mode;
+	enum ipts_mode mode;
 	u8 reserved[12];
 } __packed;
 
+#define IPTS_WORKQUEUE_SIZE      8192
+#define IPTS_WORKQUEUE_ITEM_SIZE 16
+
 /**
  * struct ipts_set_mem_window_cmd - Payload for the SET_MEM_WINDOW command.
- *
  * @data_buffer_addr_lower:     Lower 32 bits of the data buffer addresses.
  * @data_buffer_addr_upper:     Upper 32 bits of the data buffer addresses.
  * @workqueue_addr_lower:       Lower 32 bits of the workqueue buffer address.
@@ -227,8 +168,8 @@ struct ipts_set_mode_cmd {
  * @feedback_buffer_addr_upper: Upper 32 bits of the feedback buffer addresses.
  * @host2me_addr_lower:         Lower 32 bits of the host2me buffer address.
  * @host2me_addr_upper:         Upper 32 bits of the host2me buffer address.
- * @workqueue_item_size:        Constant value. (IPTS_WORKQUEUE_ITEM_SIZE)
- * @workqueue_size:             Constant value. (IPTS_WORKQUEUE_SIZE)
+ * @workqueue_item_size:        Magic value. (IPTS_WORKQUEUE_ITEM_SIZE)
+ * @workqueue_size:             Magic value. (IPTS_WORKQUEUE_SIZE)
  *
  * The data buffers are buffers that get filled with touch data by the ME.
  * The doorbell buffer is a u32 that gets incremented by the ME once a data
@@ -236,8 +177,8 @@ struct ipts_set_mode_cmd {
  *
  * The other buffers are required for using GuC submission with binary
  * firmware. Since support for GuC submission has been dropped from i915,
- * they are not used anymore, but they need to be allocated to ensure proper
- * operation.
+ * they are not used anymore, but they need to be allocated and passed,
+ * otherwise the hardware will refuse to start.
  */
 struct ipts_set_mem_window_cmd {
 	u32 data_buffer_addr_lower[IPTS_BUFFERS];
@@ -259,7 +200,6 @@ struct ipts_set_mem_window_cmd {
 
 /**
  * struct ipts_feedback_cmd - Payload for the FEEDBACK command.
- *
  * @buffer: The buffer that the ME should refill.
  */
 struct ipts_feedback_cmd {
@@ -269,8 +209,7 @@ struct ipts_feedback_cmd {
 
 /**
  * struct ipts_command - A message sent from the host to the ME.
- *
- * @code:    The message code describing the command (IPTS_CMD_*)
+ * @code:    The message code describing the command. (see IPTS_CMD_*)
  * @payload: Payload for the command, or 0 if no payload is required.
  */
 struct ipts_command {
@@ -280,14 +219,13 @@ struct ipts_command {
 
 /**
  * struct ipts_device_info - Payload for the GET_DEVICE_INFO response.
- *
  * @vendor_id:     Vendor ID of the touch sensor.
  * @device_id:     Device ID of the touch sensor.
  * @hw_rev:        Hardware revision of the touch sensor.
  * @fw_rev:        Firmware revision of the touch sensor.
  * @data_size:     Required size of one data buffer.
  * @feedback_size: Required size of one feedback buffer.
- * @mode:          Current operation mode of IPTS (IPTS_MODE_*)
+ * @mode:          Current operation mode of IPTS.
  * @max_contacts:  The amount of concurrent touches supported by the sensor.
  */
 struct ipts_get_device_info_rsp {
@@ -297,23 +235,21 @@ struct ipts_get_device_info_rsp {
 	u32 fw_rev;
 	u32 data_size;
 	u32 feedback_size;
-	u32 mode;
+	enum ipts_mode mode;
 	u8 max_contacts;
 	u8 reserved[19];
 } __packed;
 
 /**
  * struct ipts_response - A message sent from the ME to the host.
- *
- * @code:    The message code describing the response (IPTS_RSP_*)
- * @status:  The status code returned by the command. (IPTS_STATUS_*)
+ * @code:    The message code describing the response. (see IPTS_RSP_*)
+ * @status:  The status code returned by the command.
  * @payload: Payload returned by the command.
  */
 struct ipts_response {
 	u32 code;
-	u32 status;
+	enum ipts_status status;
 	u8 payload[80];
 } __packed;
 
 #endif /* _IPTS_PROTOCOL_H_ */
-

--- a/drivers/misc/ipts/receiver.c
+++ b/drivers/misc/ipts/receiver.c
@@ -15,18 +15,18 @@
 #include "resources.h"
 
 static int ipts_receiver_handle_get_device_info(struct ipts_context *ipts,
-		struct ipts_response *rsp)
+						struct ipts_response *rsp)
 {
 	struct ipts_set_mode_cmd cmd;
 
 	memcpy(&ipts->device_info, rsp->payload,
-			sizeof(struct ipts_get_device_info_rsp));
+	       sizeof(struct ipts_get_device_info_rsp));
 
 	memset(&cmd, 0, sizeof(struct ipts_set_mode_cmd));
 	cmd.mode = IPTS_MODE_MULTITOUCH;
 
-	return ipts_control_send(ipts, IPTS_CMD_SET_MODE,
-			&cmd, sizeof(struct ipts_set_mode_cmd));
+	return ipts_control_send(ipts, IPTS_CMD_SET_MODE, &cmd,
+				 sizeof(struct ipts_set_mode_cmd));
 }
 
 static int ipts_receiver_handle_set_mode(struct ipts_context *ipts)
@@ -68,15 +68,14 @@ static int ipts_receiver_handle_set_mode(struct ipts_context *ipts)
 	cmd.workqueue_size = IPTS_WORKQUEUE_SIZE;
 	cmd.workqueue_item_size = IPTS_WORKQUEUE_ITEM_SIZE;
 
-	return ipts_control_send(ipts, IPTS_CMD_SET_MEM_WINDOW,
-			&cmd, sizeof(struct ipts_set_mem_window_cmd));
+	return ipts_control_send(ipts, IPTS_CMD_SET_MEM_WINDOW, &cmd,
+				 sizeof(struct ipts_set_mem_window_cmd));
 }
 
 static int ipts_receiver_handle_set_mem_window(struct ipts_context *ipts)
 {
 	dev_info(ipts->dev, "Device %04hX:%04hX ready\n",
-			ipts->device_info.vendor_id,
-			ipts->device_info.device_id);
+		 ipts->device_info.vendor_id, ipts->device_info.device_id);
 	ipts->status = IPTS_HOST_STATUS_STARTED;
 
 	return ipts_control_send(ipts, IPTS_CMD_READY_FOR_DATA, NULL, 0);
@@ -92,7 +91,7 @@ static int ipts_receiver_handle_clear_mem_window(struct ipts_context *ipts)
 }
 
 static bool ipts_receiver_handle_error(struct ipts_context *ipts,
-		struct ipts_response *rsp)
+				       struct ipts_response *rsp)
 {
 	bool error;
 
@@ -115,8 +114,8 @@ static bool ipts_receiver_handle_error(struct ipts_context *ipts,
 	if (!error)
 		return false;
 
-	dev_err(ipts->dev, "Command 0x%08x failed: %d\n",
-			rsp->code, rsp->status);
+	dev_err(ipts->dev, "Command 0x%08x failed: %d\n", rsp->code,
+		rsp->status);
 
 	if (rsp->code == IPTS_STATUS_SENSOR_UNEXPECTED_RESET) {
 		dev_err(ipts->dev, "Sensor was reset\n");
@@ -129,7 +128,7 @@ static bool ipts_receiver_handle_error(struct ipts_context *ipts,
 }
 
 static void ipts_receiver_handle_response(struct ipts_context *ipts,
-		struct ipts_response *rsp)
+					  struct ipts_response *rsp)
 {
 	int ret;
 
@@ -158,7 +157,7 @@ static void ipts_receiver_handle_response(struct ipts_context *ipts,
 		return;
 
 	dev_err(ipts->dev, "Error while handling response 0x%08x: %d\n",
-			rsp->code, ret);
+		rsp->code, ret);
 
 	if (ipts_control_stop(ipts))
 		dev_err(ipts->dev, "Failed to stop IPTS\n");
@@ -180,4 +179,3 @@ void ipts_receiver_callback(struct mei_cl_device *cldev)
 
 	ipts_receiver_handle_response(ipts, &rsp);
 }
-

--- a/drivers/misc/ipts/receiver.h
+++ b/drivers/misc/ipts/receiver.h
@@ -14,4 +14,3 @@
 void ipts_receiver_callback(struct mei_cl_device *cldev);
 
 #endif /* _IPTS_RECEIVER_H_ */
-

--- a/drivers/misc/ipts/resources.c
+++ b/drivers/misc/ipts/resources.c
@@ -24,7 +24,7 @@ void ipts_resources_free(struct ipts_context *ipts)
 			continue;
 
 		dma_free_coherent(ipts->dev, data_buffer_size,
-				buffers[i].address, buffers[i].dma_address);
+				  buffers[i].address, buffers[i].dma_address);
 
 		buffers[i].address = NULL;
 		buffers[i].dma_address = 0;
@@ -36,7 +36,7 @@ void ipts_resources_free(struct ipts_context *ipts)
 			continue;
 
 		dma_free_coherent(ipts->dev, feedback_buffer_size,
-				buffers[i].address, buffers[i].dma_address);
+				  buffers[i].address, buffers[i].dma_address);
 
 		buffers[i].address = NULL;
 		buffers[i].dma_address = 0;
@@ -44,8 +44,8 @@ void ipts_resources_free(struct ipts_context *ipts)
 
 	if (ipts->doorbell.address) {
 		dma_free_coherent(ipts->dev, sizeof(u32),
-				ipts->doorbell.address,
-				ipts->doorbell.dma_address);
+				  ipts->doorbell.address,
+				  ipts->doorbell.dma_address);
 
 		ipts->doorbell.address = NULL;
 		ipts->doorbell.dma_address = 0;
@@ -53,8 +53,8 @@ void ipts_resources_free(struct ipts_context *ipts)
 
 	if (ipts->workqueue.address) {
 		dma_free_coherent(ipts->dev, sizeof(u32),
-				ipts->workqueue.address,
-				ipts->workqueue.dma_address);
+				  ipts->workqueue.address,
+				  ipts->workqueue.dma_address);
 
 		ipts->workqueue.address = NULL;
 		ipts->workqueue.dma_address = 0;
@@ -62,8 +62,8 @@ void ipts_resources_free(struct ipts_context *ipts)
 
 	if (ipts->host2me.address) {
 		dma_free_coherent(ipts->dev, feedback_buffer_size,
-				ipts->host2me.address,
-				ipts->host2me.dma_address);
+				  ipts->host2me.address,
+				  ipts->host2me.dma_address);
 
 		ipts->host2me.address = NULL;
 		ipts->host2me.dma_address = 0;
@@ -80,10 +80,9 @@ int ipts_resources_alloc(struct ipts_context *ipts)
 
 	buffers = ipts->data;
 	for (i = 0; i < IPTS_BUFFERS; i++) {
-		buffers[i].address = dma_alloc_coherent(ipts->dev,
-				data_buffer_size,
-				&buffers[i].dma_address,
-				GFP_KERNEL);
+		buffers[i].address =
+			dma_alloc_coherent(ipts->dev, data_buffer_size,
+					   &buffers[i].dma_address, GFP_KERNEL);
 
 		if (!buffers[i].address)
 			goto release_resources;
@@ -91,35 +90,31 @@ int ipts_resources_alloc(struct ipts_context *ipts)
 
 	buffers = ipts->feedback;
 	for (i = 0; i < IPTS_BUFFERS; i++) {
-		buffers[i].address = dma_alloc_coherent(ipts->dev,
-				feedback_buffer_size,
-				&buffers[i].dma_address,
-				GFP_KERNEL);
+		buffers[i].address =
+			dma_alloc_coherent(ipts->dev, feedback_buffer_size,
+					   &buffers[i].dma_address, GFP_KERNEL);
 
 		if (!buffers[i].address)
 			goto release_resources;
 	}
 
-	ipts->doorbell.address = dma_alloc_coherent(ipts->dev,
-			sizeof(u32),
-			&ipts->doorbell.dma_address,
-			GFP_KERNEL);
+	ipts->doorbell.address =
+		dma_alloc_coherent(ipts->dev, sizeof(u32),
+				   &ipts->doorbell.dma_address, GFP_KERNEL);
 
 	if (!ipts->doorbell.address)
 		goto release_resources;
 
-	ipts->workqueue.address = dma_alloc_coherent(ipts->dev,
-			sizeof(u32),
-			&ipts->workqueue.dma_address,
-			GFP_KERNEL);
+	ipts->workqueue.address =
+		dma_alloc_coherent(ipts->dev, sizeof(u32),
+				   &ipts->workqueue.dma_address, GFP_KERNEL);
 
 	if (!ipts->workqueue.address)
 		goto release_resources;
 
-	ipts->host2me.address = dma_alloc_coherent(ipts->dev,
-			feedback_buffer_size,
-			&ipts->host2me.dma_address,
-			GFP_KERNEL);
+	ipts->host2me.address =
+		dma_alloc_coherent(ipts->dev, feedback_buffer_size,
+				   &ipts->host2me.dma_address, GFP_KERNEL);
 
 	if (!ipts->workqueue.address)
 		goto release_resources;
@@ -131,4 +126,3 @@ release_resources:
 	ipts_resources_free(ipts);
 	return -ENOMEM;
 }
-

--- a/drivers/misc/ipts/resources.h
+++ b/drivers/misc/ipts/resources.h
@@ -15,4 +15,3 @@ int ipts_resources_alloc(struct ipts_context *ipts);
 void ipts_resources_free(struct ipts_context *ipts);
 
 #endif /* _IPTS_RESOURCES_H_ */
-

--- a/drivers/misc/ipts/uapi.c
+++ b/drivers/misc/ipts/uapi.c
@@ -113,6 +113,26 @@ static long ipts_uapi_ioctl_send_feedback(struct ipts_context *ipts,
 	return 0;
 }
 
+static long ipts_uapi_ioctl_send_reset(struct ipts_context *ipts)
+{
+	int ret;
+	struct ipts_reset_sensor_cmd cmd;
+
+	if (!ipts || ipts->status != IPTS_HOST_STATUS_STARTED)
+		return -ENODEV;
+
+	memset(&cmd, 0, sizeof(struct ipts_reset_sensor_cmd));
+	cmd.type = IPTS_RESET_TYPE_SOFT;
+
+	ret = ipts_control_send(ipts, IPTS_CMD_RESET_SENSOR, &cmd,
+				sizeof(struct ipts_reset_sensor_cmd));
+
+	if (ret)
+		return -EFAULT;
+
+	return 0;
+}
+
 static long ipts_uapi_ioctl(struct file *file, unsigned int cmd,
 			    unsigned long arg)
 {
@@ -127,6 +147,8 @@ static long ipts_uapi_ioctl(struct file *file, unsigned int cmd,
 		return ipts_uapi_ioctl_get_doorbell(ipts, arg);
 	case IPTS_IOCTL_SEND_FEEDBACK:
 		return ipts_uapi_ioctl_send_feedback(ipts, file);
+	case IPTS_IOCTL_SEND_RESET:
+		return ipts_uapi_ioctl_send_reset(ipts);
 	default:
 		return -ENOTTY;
 	}

--- a/drivers/misc/ipts/uapi.c
+++ b/drivers/misc/ipts/uapi.c
@@ -20,8 +20,8 @@
 
 struct ipts_uapi uapi;
 
-static ssize_t ipts_uapi_read(struct file *file, char __user *buf,
-		size_t count, loff_t *offset)
+static ssize_t ipts_uapi_read(struct file *file, char __user *buf, size_t count,
+			      loff_t *offset)
 {
 	int buffer;
 	int maxbytes;
@@ -43,7 +43,7 @@ static ssize_t ipts_uapi_read(struct file *file, char __user *buf,
 }
 
 static long ipts_uapi_ioctl_get_device_ready(struct ipts_context *ipts,
-		unsigned long arg)
+					     unsigned long arg)
 {
 	void __user *buffer = (void __user *)arg;
 	u8 ready = 0;
@@ -58,7 +58,7 @@ static long ipts_uapi_ioctl_get_device_ready(struct ipts_context *ipts,
 }
 
 static long ipts_uapi_ioctl_get_device_info(struct ipts_context *ipts,
-		unsigned long arg)
+					    unsigned long arg)
 {
 	struct ipts_device_info info;
 	void __user *buffer = (void __user *)arg;
@@ -79,7 +79,7 @@ static long ipts_uapi_ioctl_get_device_info(struct ipts_context *ipts,
 }
 
 static long ipts_uapi_ioctl_get_doorbell(struct ipts_context *ipts,
-		unsigned long arg)
+					 unsigned long arg)
 {
 	void __user *buffer = (void __user *)arg;
 
@@ -93,7 +93,7 @@ static long ipts_uapi_ioctl_get_doorbell(struct ipts_context *ipts,
 }
 
 static long ipts_uapi_ioctl_send_feedback(struct ipts_context *ipts,
-		struct file *file)
+					  struct file *file)
 {
 	int ret;
 	struct ipts_feedback_cmd cmd;
@@ -104,8 +104,8 @@ static long ipts_uapi_ioctl_send_feedback(struct ipts_context *ipts,
 	memset(&cmd, 0, sizeof(struct ipts_feedback_cmd));
 	cmd.buffer = MINOR(file->f_path.dentry->d_inode->i_rdev);
 
-	ret = ipts_control_send(ipts, IPTS_CMD_FEEDBACK,
-				&cmd, sizeof(struct ipts_feedback_cmd));
+	ret = ipts_control_send(ipts, IPTS_CMD_FEEDBACK, &cmd,
+				sizeof(struct ipts_feedback_cmd));
 
 	if (ret)
 		return -EFAULT;
@@ -114,7 +114,7 @@ static long ipts_uapi_ioctl_send_feedback(struct ipts_context *ipts,
 }
 
 static long ipts_uapi_ioctl(struct file *file, unsigned int cmd,
-		unsigned long arg)
+			    unsigned long arg)
 {
 	struct ipts_context *ipts = uapi.ipts;
 
@@ -165,8 +165,8 @@ int ipts_uapi_init(void)
 	cdev_add(&uapi.cdev, MKDEV(major, 0), IPTS_BUFFERS);
 
 	for (i = 0; i < IPTS_BUFFERS; i++) {
-		device_create(uapi.class, NULL,
-				MKDEV(major, i), NULL, "ipts/%d", i);
+		device_create(uapi.class, NULL, MKDEV(major, i), NULL,
+			      "ipts/%d", i);
 	}
 
 	return 0;
@@ -187,4 +187,3 @@ void ipts_uapi_free(void)
 	unregister_chrdev_region(MKDEV(major, 0), MINORMASK);
 	class_destroy(uapi.class);
 }
-

--- a/drivers/misc/ipts/uapi.c
+++ b/drivers/misc/ipts/uapi.c
@@ -46,7 +46,10 @@ static long ipts_uapi_ioctl_get_device_ready(struct ipts_context *ipts,
 		unsigned long arg)
 {
 	void __user *buffer = (void __user *)arg;
-	u8 ready = ipts->status == IPTS_HOST_STATUS_STARTED;
+	u8 ready = 0;
+
+	if (ipts)
+		ready = ipts->status == IPTS_HOST_STATUS_STARTED;
 
 	if (copy_to_user(buffer, &ready, sizeof(u8)))
 		return -EFAULT;
@@ -60,7 +63,7 @@ static long ipts_uapi_ioctl_get_device_info(struct ipts_context *ipts,
 	struct ipts_device_info info;
 	void __user *buffer = (void __user *)arg;
 
-	if (ipts->status != IPTS_HOST_STATUS_STARTED)
+	if (!ipts || ipts->status != IPTS_HOST_STATUS_STARTED)
 		return -ENODEV;
 
 	info.vendor = ipts->device_info.vendor_id;
@@ -80,7 +83,7 @@ static long ipts_uapi_ioctl_get_doorbell(struct ipts_context *ipts,
 {
 	void __user *buffer = (void __user *)arg;
 
-	if (ipts->status != IPTS_HOST_STATUS_STARTED)
+	if (!ipts || ipts->status != IPTS_HOST_STATUS_STARTED)
 		return -ENODEV;
 
 	if (copy_to_user(buffer, ipts->doorbell.address, sizeof(u32)))
@@ -95,7 +98,7 @@ static long ipts_uapi_ioctl_send_feedback(struct ipts_context *ipts,
 	int ret;
 	struct ipts_feedback_cmd cmd;
 
-	if (ipts->status != IPTS_HOST_STATUS_STARTED)
+	if (!ipts || ipts->status != IPTS_HOST_STATUS_STARTED)
 		return -ENODEV;
 
 	memset(&cmd, 0, sizeof(struct ipts_feedback_cmd));
@@ -114,9 +117,6 @@ static long ipts_uapi_ioctl(struct file *file, unsigned int cmd,
 		unsigned long arg)
 {
 	struct ipts_context *ipts = uapi.ipts;
-
-	if (!ipts)
-		return -ENODEV;
 
 	switch (cmd) {
 	case IPTS_IOCTL_GET_DEVICE_READY:

--- a/drivers/misc/ipts/uapi.h
+++ b/drivers/misc/ipts/uapi.h
@@ -34,7 +34,7 @@ struct ipts_device_info {
 
 #define IPTS_IOCTL_GET_DEVICE_READY _IOR(0x86, 0x01, __u8)
 #define IPTS_IOCTL_GET_DEVICE_INFO  _IOR(0x86, 0x02, struct ipts_device_info)
-#define IPTS_IOCTL_GET_DOORBELL     _IOR(0x86, 0x03, __u32)
+#define IPTS_IOCTL_GET_DOORBELL	    _IOR(0x86, 0x03, __u32)
 #define IPTS_IOCTL_SEND_FEEDBACK    _IO(0x86, 0x04)
 
 void ipts_uapi_link(struct ipts_context *ipts);
@@ -44,4 +44,3 @@ int ipts_uapi_init(void);
 void ipts_uapi_free(void);
 
 #endif /* _IPTS_UAPI_H_ */
-

--- a/drivers/misc/ipts/uapi.h
+++ b/drivers/misc/ipts/uapi.h
@@ -36,6 +36,7 @@ struct ipts_device_info {
 #define IPTS_IOCTL_GET_DEVICE_INFO  _IOR(0x86, 0x02, struct ipts_device_info)
 #define IPTS_IOCTL_GET_DOORBELL	    _IOR(0x86, 0x03, __u32)
 #define IPTS_IOCTL_SEND_FEEDBACK    _IO(0x86, 0x04)
+#define IPTS_IOCTL_SEND_RESET	    _IO(0x86, 0x05)
 
 void ipts_uapi_link(struct ipts_context *ipts);
 void ipts_uapi_unlink(void);

--- a/drivers/misc/mei/init.c
+++ b/drivers/misc/mei/init.c
@@ -302,10 +302,10 @@ void mei_stop(struct mei_device *dev)
 {
 	dev_dbg(dev->dev, "stopping the device.\n");
 
-	mei_cl_bus_remove_devices(dev);
 	mutex_lock(&dev->device_lock);
 	mei_set_devstate(dev, MEI_DEV_POWER_DOWN);
 	mutex_unlock(&dev->device_lock);
+	mei_cl_bus_remove_devices(dev);
 
 	mei_cancel_work(dev);
 


### PR DESCRIPTION
These changes have been sitting in the module repo for a while now, and nobody has screamed at me yet, so lets sync them into the patches.

This has a bit of everything:
 - You can now reset the sensor from userspace, the master branch of iptsd already has support for this
 - It doesnt require patches to the MEI bus anymore, so at least on gen4 - gen6 IPTS will work as a DKMS module. Gen7 will need upstreaming of the device ID's
 - A lot of formatting stuff for eventual upstreaming (not that I want to work on that now, but it doesnt hurt).