### PR TITLE
Updates and Improvements to ov5693

### DIFF
--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -63,11 +63,11 @@ MODULE_PARM_DESC(up_delay,
 /* Exposure/gain */
 
 #define OV5693_EXPOSURE_CTRL_HH_REG		0x3500
-#define OV5693_EXPOSURE_CTRL_HH(v)		(((v) & GENMASK(18, 16)) >> 16)
+#define OV5693_EXPOSURE_CTRL_HH(v)		(((v) & GENMASK(14, 12)) >> 12)
 #define OV5693_EXPOSURE_CTRL_H_REG		0x3501
-#define OV5693_EXPOSURE_CTRL_H(v)		(((v) & GENMASK(15, 8)) >> 8)
+#define OV5693_EXPOSURE_CTRL_H(v)		(((v) & GENMASK(11, 4)) >> 4)
 #define OV5693_EXPOSURE_CTRL_L_REG		0x3502
-#define OV5693_EXPOSURE_CTRL_L(v)		((v) & GENMASK(7, 0))
+#define OV5693_EXPOSURE_CTRL_L(v)		(((v) & GENMASK(3, 0)) << 4)
 #define OV5693_EXPOSURE_GAIN_MANUAL_REG		0x3509
 
 #define OV5693_GAIN_CTRL_H_REG			0x3504

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -1492,6 +1492,12 @@ static int ov5693_s_stream(struct v4l2_subdev *sd, int enable)
 		}
 	}
 
+	ret = __v4l2_ctrl_handler_setup(&dev->ctrl_handler);
+	if (ret) {
+		power_down(sd);
+		return ret;
+	}
+
 	ret = ov5693_write_reg(client, OV5693_8BIT, OV5693_SW_STREAM,
 			       enable ? OV5693_START_STREAMING :
 			       OV5693_STOP_STREAMING);

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -770,30 +770,35 @@ static int ov5693_t_focus_rel(struct v4l2_subdev *sd, s32 value)
 
 static int ov5693_get_exposure(struct ov5693_device *sensor)
 {
-	u16 reg_v, reg_v2;
+	u32 exposure = 0;
+	u16 tmp;
 	int ret = 0;
 
 	/* get exposure */
 	ret = ov5693_read_reg(sensor->i2c_client, OV5693_8BIT,
 			      OV5693_EXPOSURE_L,
-			      &reg_v);
+			      &tmp);
 	if (ret)
 		return ret;
+
+	exposure |= ((tmp >> 4) & 0b1111);
 
 	ret = ov5693_read_reg(sensor->i2c_client, OV5693_8BIT,
 			      OV5693_EXPOSURE_M,
-			      &reg_v2);
+			      &tmp);
 	if (ret)
 		return ret;
 
-	reg_v += reg_v2 << 8;
+	exposure |= (tmp << 4);
 	ret = ov5693_read_reg(sensor->i2c_client, OV5693_8BIT,
 			      OV5693_EXPOSURE_H,
-			      &reg_v2);
+			      &tmp);
 	if (ret)
 		return ret;
 
-	printk("exposure set to: %u\n", reg_v + (((u32)reg_v2 << 16)));
+	exposure |= (tmp << 12);
+
+	printk("exposure set to: %u\n", exposure);
 	return ret;
 }
 

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -1266,12 +1266,8 @@ static int ov5693_remove(struct i2c_client *client)
 {
 	struct v4l2_subdev *sd = i2c_get_clientdata(client);
 	struct ov5693_device *ov5693 = to_ov5693_sensor(sd);
-	unsigned int i = OV5693_NUM_SUPPLIES;
 
 	dev_info(&client->dev, "%s...\n", __func__);
-
-	while (i--)
-		regulator_put(ov5693->supplies[i].consumer);
 
 	v4l2_async_unregister_subdev(sd);
 
@@ -1401,7 +1397,7 @@ static int ov5693_get_regulators(struct ov5693_device *ov5693)
 	for (i = 0; i < OV5693_NUM_SUPPLIES; i++)
 		ov5693->supplies[i].supply = ov5693_supply_names[i];
 
-	return regulator_bulk_get(&ov5693->client->dev,
+	return devm_regulator_bulk_get(&ov5693->client->dev,
 				       OV5693_NUM_SUPPLIES,
 				       ov5693->supplies);
 }

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -20,19 +20,11 @@
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/device.h>
-#include <linux/errno.h>
 #include <linux/i2c.h>
-#include <linux/init.h>
-#include <linux/io.h>
-#include <linux/kernel.h>
-#include <linux/kmod.h>
 #include <linux/module.h>
-#include <linux/mm.h>
 #include <linux/pm_runtime.h>
 #include <linux/regulator/consumer.h>
 #include <linux/slab.h>
-#include <linux/string.h>
-#include <linux/types.h>
 #include <media/v4l2-device.h>
 #include <media/v4l2-fwnode.h>
 

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -1610,7 +1610,6 @@ static int ov5693_init_controls(struct ov5693_device *ov5693)
 	struct i2c_client *client = v4l2_get_subdevdata(&ov5693->sd);
 	const struct v4l2_ctrl_ops *ops = &ov5693_ctrl_ops;
 	struct v4l2_fwnode_device_properties props;
-	struct v4l2_ctrl *ctrl;
 	unsigned int i;
 	int ret;
 	int hblank;
@@ -1628,15 +1627,17 @@ static int ov5693_init_controls(struct ov5693_device *ov5693)
 				     NULL);
 
 	/* link freq */
-	ctrl = v4l2_ctrl_new_int_menu(&ov5693->ctrl_handler, NULL,
-				      V4L2_CID_LINK_FREQ,
-				      0, 0, link_freq_menu_items);
-	if (ctrl)
-		ctrl->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+	ov5693->ctrls.link_freq = v4l2_ctrl_new_int_menu(&ov5693->ctrl_handler,
+							 NULL, V4L2_CID_LINK_FREQ,
+							 0, 0, link_freq_menu_items);
+	if (ov5693->ctrls.link_freq)
+		ov5693->ctrls.link_freq->flags |= V4L2_CTRL_FLAG_READ_ONLY;
 
 	/* pixel rate */
-	v4l2_ctrl_new_std(&ov5693->ctrl_handler, NULL, V4L2_CID_PIXEL_RATE,
-			  0, OV5693_PIXEL_RATE, 1, OV5693_PIXEL_RATE);
+	ov5693->ctrls.pixel_rate = v4l2_ctrl_new_std(&ov5693->ctrl_handler, NULL,
+						     V4L2_CID_PIXEL_RATE, 0,
+						     OV5693_PIXEL_RATE, 1,
+						     OV5693_PIXEL_RATE);
 
 	if (ov5693->ctrl_handler.error) {
 		ov5693_remove(client);
@@ -1645,25 +1646,32 @@ static int ov5693_init_controls(struct ov5693_device *ov5693)
 
 	/* Exposure */
 
-	v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops, V4L2_CID_EXPOSURE, 16, 1048575, 16,
-			  512);
+	ov5693->ctrls.exposure = v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops,
+						   V4L2_CID_EXPOSURE, 16,
+						   1048575, 16, 512);
 
 	/* Gain */
 
-	v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops, V4L2_CID_ANALOGUE_GAIN, 1, 1023, 1, 128);
-	v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops, V4L2_CID_DIGITAL_GAIN, 1, 3999, 1, 1000);
+	ov5693->ctrls.analogue_gain = v4l2_ctrl_new_std(&ov5693->ctrl_handler,
+							ops, V4L2_CID_ANALOGUE_GAIN,
+							1, 1023, 1, 128);
+	ov5693->ctrls.digital_gain = v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops,
+						       V4L2_CID_DIGITAL_GAIN, 1,
+						       3999, 1, 1000);
 
 	/* Flip */
 
-	v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops, V4L2_CID_HFLIP, 0, 1, 1, 0);
-	v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops, V4L2_CID_VFLIP, 0, 1, 1, 0);
+	ov5693->ctrls.hflip = v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops,
+						V4L2_CID_HFLIP, 0, 1, 1, 0);
+	ov5693->ctrls.vflip = v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops,
+						V4L2_CID_VFLIP, 0, 1, 1, 0);
 
 	hblank = OV5693_PPL_DEFAULT - ov5693->mode->width;
-	ov5693->hblank = v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops,
-					   V4L2_CID_HBLANK, hblank, hblank,
-					   1, hblank);
-	if (ov5693->hblank)
-		ov5693->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+	ov5693->ctrls.hblank = v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops,
+						 V4L2_CID_HBLANK, hblank, hblank,
+						 1, hblank);
+	if (ov5693->ctrls.hblank)
+		ov5693->ctrls.hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
 
 	/* set properties from fwnode (e.g. rotation, orientation) */
 	ret = v4l2_fwnode_device_parse(&client->dev, &props);

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -526,41 +526,6 @@ err:
 }
 
 /* Exposure */
-
-static int ov5693_get_exposure(struct ov5693_device *ov5693)
-{
-	u32 exposure = 0;
-	u16 tmp;
-	int ret = 0;
-
-	/* get exposure */
-	ret = ov5693_read_reg(ov5693->client, OV5693_8BIT,
-			      OV5693_EXPOSURE_L,
-			      &tmp);
-	if (ret)
-		return ret;
-
-	exposure |= ((tmp >> 4) & 0b1111);
-
-	ret = ov5693_read_reg(ov5693->client, OV5693_8BIT,
-			      OV5693_EXPOSURE_M,
-			      &tmp);
-	if (ret)
-		return ret;
-
-	exposure |= (tmp << 4);
-	ret = ov5693_read_reg(ov5693->client, OV5693_8BIT,
-			      OV5693_EXPOSURE_H,
-			      &tmp);
-	if (ret)
-		return ret;
-
-	exposure |= (tmp << 12);
-
-	printk("exposure set to: %u\n", exposure);
-	return ret;
-}
-
 static int ov5693_exposure_configure(struct ov5693_device *ov5693, u32 exposure)
 {
 	int ret;
@@ -571,7 +536,6 @@ static int ov5693_exposure_configure(struct ov5693_device *ov5693, u32 exposure)
 	 */
 	exposure = exposure * 16;
 
-	ov5693_get_exposure(ov5693);
 	ret = ov5693_write_reg(ov5693->client, OV5693_8BIT,
 			OV5693_EXPOSURE_CTRL_HH_REG, OV5693_EXPOSURE_CTRL_HH(exposure));
 	if (ret)
@@ -586,7 +550,6 @@ static int ov5693_exposure_configure(struct ov5693_device *ov5693, u32 exposure)
 			OV5693_EXPOSURE_CTRL_L_REG, OV5693_EXPOSURE_CTRL_L(exposure));
 	if (ret)
 		return ret;
-	ov5693_get_exposure(ov5693);
 
 	return 0;
 }

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -1425,7 +1425,7 @@ static int ov5693_probe(struct i2c_client *client)
 
 	dev_info(&client->dev, "%s() called", __func__);
 
-	ov5693 = kzalloc(sizeof(*ov5693), GFP_KERNEL);
+	ov5693 = devm_kzalloc(&client->dev, sizeof(*ov5693), GFP_KERNEL);
 	if (!ov5693)
 		return -ENOMEM;
 

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -29,6 +29,7 @@
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 #include <linux/mm.h>
+#include <linux/pm_runtime.h>
 #include <linux/regulator/consumer.h>
 #include <linux/slab.h>
 #include <linux/string.h>
@@ -935,6 +936,10 @@ static int ov5693_s_ctrl(struct v4l2_ctrl *ctrl)
 					 ov5693->ctrls.exposure->val : exposure_max);
 	}
 
+	/* Only apply changes to the controls if the device is powered up */
+	if (!pm_runtime_get_if_in_use(&ov5693->client->dev))
+		return 0;
+
 	switch (ctrl->id) {
 	case V4L2_CID_FOCUS_ABSOLUTE:
 		dev_dbg(&client->dev, "%s: CID_FOCUS_ABSOLUTE:%d.\n",
@@ -950,27 +955,23 @@ static int ov5693_s_ctrl(struct v4l2_ctrl *ctrl)
 		dev_dbg(&client->dev, "%s: CID_EXPOSURE:%d.\n",
 			__func__, ctrl->val);
 		ret = ov5693_exposure_configure(ov5693, ctrl->val);
-		if (ret)
-			return ret;
 		break;
 	case V4L2_CID_ANALOGUE_GAIN:
 		dev_dbg(&client->dev, "%s: CID_ANALOGUE_GAIN:%d.\n",
 			__func__, ctrl->val);
 		ret = ov5693_analog_gain_configure(ov5693, ctrl->val);
-		if (ret)
-			return ret;
 		break;
 	case V4L2_CID_DIGITAL_GAIN:
 		dev_dbg(&client->dev, "%s: CID_DIGITAL_GAIN:%d.\n",
 			__func__, ctrl->val);
 		ret = ov5693_gain_configure(ov5693, ctrl->val);
-		if (ret)
-			return ret;
 		break;
 	case V4L2_CID_HFLIP:
-		return ov5693_flip_horz_configure(ov5693, !!ctrl->val);
+		ret = ov5693_flip_horz_configure(ov5693, !!ctrl->val);
+		break;
 	case V4L2_CID_VFLIP:
-		return ov5693_flip_vert_configure(ov5693, !!ctrl->val);
+		ret = ov5693_flip_vert_configure(ov5693, !!ctrl->val);
+		break;
 	case V4L2_CID_VBLANK:
 		ret = ov5693_write_reg(client, OV5693_16BIT, OV5693_TIMING_VTS_H,
 				       ov5693->mode->height + ctrl->val);
@@ -978,6 +979,9 @@ static int ov5693_s_ctrl(struct v4l2_ctrl *ctrl)
 	default:
 		ret = -EINVAL;
 	}
+
+	pm_runtime_put(&ov5693->client->dev);
+
 	return ret;
 }
 
@@ -1093,6 +1097,106 @@ static int ov5693_init(struct v4l2_subdev *sd)
 	return 0;
 }
 
+static int ov5693_sw_standby(struct ov5693_device *ov5693, bool standby)
+{
+	return ov5693_write_reg(ov5693->client, OV5693_8BIT, OV5693_SW_STREAM,
+			       standby ? OV5693_STOP_STREAMING : OV5693_START_STREAMING);
+}
+
+static void ov5693_sensor_powerdown(struct ov5693_device *ov5693)
+{
+	gpiod_set_value_cansleep(ov5693->reset, 1);
+	gpiod_set_value_cansleep(ov5693->powerdown, 1);
+
+	regulator_bulk_disable(OV5693_NUM_SUPPLIES, ov5693->supplies);
+
+	clk_disable_unprepare(ov5693->clk);
+	gpiod_set_value_cansleep(ov5693->indicator_led, 0);
+}
+
+
+static int ov5693_sensor_powerup(struct ov5693_device *ov5693)
+{
+	int ret = 0;
+
+	gpiod_set_value_cansleep(ov5693->reset, 1);
+	gpiod_set_value_cansleep(ov5693->powerdown, 1);
+
+	ret = clk_prepare_enable(ov5693->clk);
+	if (ret) {
+		dev_err(&ov5693->client->dev, "Failed to enable clk\n");
+		goto fail_power;
+	}
+
+	ret = regulator_bulk_enable(OV5693_NUM_SUPPLIES, ov5693->supplies);
+	if (ret) {
+		dev_err(&ov5693->client->dev, "Failed to enable regulators\n");
+		goto fail_power;
+	}
+
+	gpiod_set_value_cansleep(ov5693->reset, 0);
+	gpiod_set_value_cansleep(ov5693->powerdown, 0);
+	gpiod_set_value_cansleep(ov5693->indicator_led, 1);
+
+	usleep_range(20000, 25000);
+
+	return 0;
+
+fail_power:
+	ov5693_sensor_powerdown(ov5693);
+	return ret;
+}
+
+static int __maybe_unused ov5693_sensor_suspend(struct device *dev)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct v4l2_subdev *sd = i2c_get_clientdata(client);
+	struct ov5693_device *ov5693 = to_ov5693_sensor(sd);
+	int ret;
+
+	mutex_lock(&ov5693->lock);
+
+	if (ov5693->streaming) {
+		ret = ov5693_sw_standby(ov5693, true);
+		if (ret)
+			goto out_unlock;
+	}
+
+	ov5693_sensor_powerdown(ov5693);
+
+out_unlock:
+	mutex_unlock(&ov5693->lock);
+	return ret;
+}
+
+static int __maybe_unused ov5693_sensor_resume(struct device *dev)
+{
+	struct i2c_client *client = i2c_verify_client(dev);
+	struct v4l2_subdev *sd = i2c_get_clientdata(client);
+	struct ov5693_device *ov5693 = to_ov5693_sensor(sd);
+	int ret;
+
+	mutex_lock(&ov5693->lock);
+
+	ret = ov5693_sensor_powerup(ov5693);
+	if (ret)
+		goto out_unlock;
+
+	if (ov5693->streaming) {
+		ret = ov5693_sw_standby(ov5693, false);
+		if (ret)
+			goto err_power;
+	}
+
+	goto out_unlock;
+
+err_power:
+	ov5693_sensor_powerdown(ov5693);
+out_unlock:
+	mutex_unlock(&ov5693->lock);
+	return ret;
+}
+
 static int __power_up(struct v4l2_subdev *sd)
 {
 	struct i2c_client *client = v4l2_get_subdevdata(sd);
@@ -1134,6 +1238,7 @@ static int power_down(struct v4l2_subdev *sd)
 	ov5693->focus = OV5693_INVALID_CONFIG;
 
 	gpiod_set_value_cansleep(ov5693->reset, 1);
+	gpiod_set_value_cansleep(ov5693->powerdown, 1);
 
 	clk_disable_unprepare(ov5693->clk);
 
@@ -1333,7 +1438,7 @@ static int ov5693_set_fmt(struct v4l2_subdev *sd,
 	}
 
 	for (cnt = 0; cnt < OV5693_POWER_UP_RETRY_NUM; cnt++) {
-		ret = power_up(sd);
+		ret = ov5693_sensor_powerup(ov5693);
 		if (ret) {
 			dev_err(&client->dev, "power up failed\n");
 			continue;
@@ -1475,38 +1580,34 @@ static int ov5693_detect(struct i2c_client *client)
 
 static int ov5693_s_stream(struct v4l2_subdev *sd, int enable)
 {
-	struct ov5693_device *dev = to_ov5693_sensor(sd);
-	struct i2c_client *client = v4l2_get_subdevdata(sd);
+	struct ov5693_device *ov5693 = to_ov5693_sensor(sd);
 	int ret;
 
-	mutex_lock(&dev->lock);
-
-	/* power_on() here before streaming for regular PCs. */
 	if (enable) {
-		ret = power_up(sd);
-		if (ret) {
-			dev_err(&client->dev, "sensor power-up error\n");
-			goto out;
-		}
+		ret = pm_runtime_get_sync(&ov5693->client->dev);
+		if (ret < 0)
+			goto err_power_down;
 	}
 
-	ret = __v4l2_ctrl_handler_setup(&dev->ctrl_handler);
-	if (ret) {
-		power_down(sd);
-		return ret;
-	}
+	ret = __v4l2_ctrl_handler_setup(&ov5693->ctrl_handler);
+	if (ret)
+		goto err_power_down;
 
-	ret = ov5693_write_reg(client, OV5693_8BIT, OV5693_SW_STREAM,
-			       enable ? OV5693_START_STREAMING :
-			       OV5693_STOP_STREAMING);
+	mutex_lock(&ov5693->lock);
+	ret = ov5693_sw_standby(ov5693, !enable);
+	mutex_unlock(&ov5693->lock);
+
+	if (ret)
+		goto err_power_down;
+	ov5693->streaming = !!enable;
 
 	/* power_off() here after streaming for regular PCs. */
 	if (!enable)
-		power_down(sd);
+		pm_runtime_put(&ov5693->client->dev);
 
-out:
-	mutex_unlock(&dev->lock);
-
+	return 0;
+err_power_down:
+	pm_runtime_put_noidle(&ov5693->client->dev);
 	return ret;
 }
 
@@ -1517,7 +1618,7 @@ static int ov5693_s_config(struct v4l2_subdev *sd, int irq)
 	int ret = 0;
 
 	mutex_lock(&ov5693->lock);
-	ret = power_up(sd);
+	ret = ov5693_sensor_powerup(ov5693);
 	if (ret) {
 		dev_err(&client->dev, "ov5693 power-up err.\n");
 		goto fail_power_on;
@@ -1536,17 +1637,14 @@ static int ov5693_s_config(struct v4l2_subdev *sd, int irq)
 	ov5693->otp_data = ov5693_otp_read(sd);
 
 	/* turn off sensor, after probed */
-	ret = power_down(sd);
-	if (ret) {
-		dev_err(&client->dev, "ov5693 power-off err.\n");
-		goto fail_power_on;
-	}
+	ov5693_sensor_powerdown(ov5693);
+
 	mutex_unlock(&ov5693->lock);
 
 	return ret;
 
 fail_power_on:
-	power_down(sd);
+	ov5693_sensor_powerdown(ov5693);
 	dev_err(&client->dev, "sensor power-gating failed\n");
 	mutex_unlock(&ov5693->lock);
 	return ret;
@@ -1830,6 +1928,9 @@ static int ov5693_probe(struct i2c_client *client)
 	if (ret)
 		ov5693_remove(client);
 
+	pm_runtime_enable(&client->dev);
+	pm_runtime_set_suspended(&client->dev);
+
 	ret = v4l2_async_register_subdev_sensor_common(&ov5693->sd);
 	if (ret) {
 		dev_err(&client->dev, "failed to register V4L2 subdev: %d", ret);
@@ -1839,6 +1940,7 @@ static int ov5693_probe(struct i2c_client *client)
 	return ret;
 
 media_entity_cleanup:
+	pm_runtime_disable(&client->dev);
 	media_entity_cleanup(&ov5693->sd.entity);
 out_put_reset:
         gpiod_put(ov5693->reset);
@@ -1847,6 +1949,10 @@ out_free:
 	kfree(ov5693);
 	return ret;
 }
+
+static const struct dev_pm_ops ov5693_pm_ops = {
+	SET_RUNTIME_PM_OPS(ov5693_sensor_suspend, ov5693_sensor_resume, NULL)
+};
 
 static const struct acpi_device_id ov5693_acpi_match[] = {
 	{"INT33BE"},
@@ -1858,6 +1964,7 @@ static struct i2c_driver ov5693_driver = {
 	.driver = {
 		.name = "ov5693",
 		.acpi_match_table = ov5693_acpi_match,
+		.pm = &ov5693_pm_ops,
 	},
 	.probe_new = ov5693_probe,
 	.remove = ov5693_remove,

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -105,8 +105,6 @@ MODULE_PARM_DESC(up_delay,
 #define OV5693_PIXEL_ARRAY_WIDTH	2592U
 #define OV5693_PIXEL_ARRAY_HEIGHT	1944U
 
-#define	OV5693_PPL_DEFAULT		2800
-
 static int vcm_ad_i2c_wr8(struct i2c_client *client, u8 reg, u8 val)
 {
 	int err;
@@ -1666,7 +1664,7 @@ static int ov5693_init_controls(struct ov5693_device *ov5693)
 	ov5693->ctrls.vflip = v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops,
 						V4L2_CID_VFLIP, 0, 1, 1, 0);
 
-	hblank = OV5693_PPL_DEFAULT - ov5693->mode->width;
+	hblank = ov5693->mode->pixels_per_line - ov5693->mode->width;
 	ov5693->ctrls.hblank = v4l2_ctrl_new_std(&ov5693->ctrl_handler, ops,
 						 V4L2_CID_HBLANK, hblank, hblank,
 						 1, hblank);

--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -1421,6 +1421,7 @@ static int ov5693_get_regulators(struct ov5693_device *ov5693)
 static int ov5693_probe(struct i2c_client *client)
 {
 	struct ov5693_device *ov5693;
+	u32 clk_rate;
 	int ret = 0;
 
 	dev_info(&client->dev, "%s() called", __func__);
@@ -1438,6 +1439,13 @@ static int ov5693_probe(struct i2c_client *client)
 	ov5693->clk = devm_clk_get(&client->dev, "xvclk");
 	if (IS_ERR(ov5693->clk)) {
 		dev_err(&client->dev, "Error getting clock\n");
+		return -EINVAL;
+	}
+
+	clk_rate = clk_get_rate(ov5693->clk);
+	if (clk_rate != OV5693_XVCLK_FREQ) {
+		dev_err(&client->dev, "Unsupported clk freq %u, expected %u\n",
+			clk_rate, OV5693_XVCLK_FREQ);
 		return -EINVAL;
 	}
 

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -581,7 +581,6 @@ static struct ov5693_reg const ov5693_654x496[] = {
 	{OV5693_8BIT, 0x3820, 0x04},
 	{OV5693_8BIT, 0x3821, 0x1f},
 	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -626,7 +625,6 @@ static struct ov5693_reg const ov5693_1296x976[] = {
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x00},
 	{OV5693_8BIT, 0x5041, 0x84}, /* scale is auto enabled */
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 
 };
@@ -656,7 +654,6 @@ static struct ov5693_reg const ov5693_336x256[] = {
 	{OV5693_8BIT, 0x3820, 0x04},
 	{OV5693_8BIT, 0x3821, 0x1f},
 	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -683,7 +680,6 @@ static struct ov5693_reg const ov5693_368x304[] = {
 	{OV5693_8BIT, 0x3820, 0x04},
 	{OV5693_8BIT, 0x3821, 0x1f},
 	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -715,7 +711,6 @@ static struct ov5693_reg const ov5693_192x160[] = {
 	{OV5693_8BIT, 0x3820, 0x04},
 	{OV5693_8BIT, 0x3821, 0x1f},
 	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -742,7 +737,6 @@ static struct ov5693_reg const ov5693_736x496[] = {
 	{OV5693_8BIT, 0x3820, 0x04},
 	{OV5693_8BIT, 0x3821, 0x1f},
 	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 #endif
@@ -771,7 +765,6 @@ static struct ov5693_reg const ov5693_736x496[] = {
 	{OV5693_8BIT, 0x3820, 0x01},
 	{OV5693_8BIT, 0x3821, 0x1f},
 	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 */
@@ -802,7 +795,6 @@ static struct ov5693_reg const ov5693_976x556[] = {
 	{OV5693_8BIT, 0x3820, 0x00},
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -841,7 +833,6 @@ static struct ov5693_reg const ov5693_1296x736[] = {
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x00},
 	{OV5693_8BIT, 0x5041, 0x84}, /* scale is auto enabled */
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -868,7 +859,6 @@ static struct ov5693_reg const ov5693_1636p_30fps[] = {
 	{OV5693_8BIT, 0x3820, 0x00},
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 #endif
@@ -904,7 +894,6 @@ static struct ov5693_reg const ov5693_1616x1216_30fps[] = {
 	{OV5693_8BIT, 0x3821, 0x1e},	/*MIRROR control*/
 	{OV5693_8BIT, 0x5002, 0x00},
 	{OV5693_8BIT, 0x5041, 0x84},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -935,7 +924,6 @@ static struct ov5693_reg const ov5693_1940x1096[] = {
 	{OV5693_8BIT, 0x3820, 0x00},
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -1029,7 +1017,6 @@ static struct ov5693_reg const ov5693_2592x1944_30fps[] = {
 	{OV5693_8BIT, 0x3820, 0x00},
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 #endif
@@ -1073,7 +1060,6 @@ static struct ov5693_reg const ov5693_1424x1168_30fps[] = {
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x00},
 	{OV5693_8BIT, 0x5041, 0x84}, /* scale is auto enabled */
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 #endif
@@ -1114,7 +1100,6 @@ static struct ov5693_reg const ov5693_736x496_30fps[] = {
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x00},
 	{OV5693_8BIT, 0x5041, 0x84}, /* scale is auto enabled */
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 
@@ -1141,7 +1126,6 @@ static struct ov5693_reg const ov5693_2576x1936_30fps[] = {
 	{OV5693_8BIT, 0x3820, 0x00},
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_8BIT, 0x0100, 0x01},
 	{OV5693_TOK_TERM, 0, 0}
 };
 

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -127,8 +127,8 @@ struct ov5693_resolution {
 	u8 *desc;
 	const struct ov5693_reg *regs;
 	int res;
-	int width;
-	int height;
+	u32 width;
+	u32 height;
 	int fps;
 	int pix_clk_freq;
 	u16 pixels_per_line;
@@ -178,7 +178,6 @@ struct ov5693_device {
 	struct camera_sensor_platform_data *platform_data;
 	ktime_t timestamp_t_focus_abs;
 	int vt_pix_clk_freq_mhz;
-	int fmt_idx;
 	int run_mode;
 	int otp_size;
 	u8 *otp_data;

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -186,13 +186,13 @@
 #define OV5693_OTP_MODE_READ		1
 
 /* link freq and pixel rate required for IPU3 */
-#define OV5693_LINK_FREQ_640MHZ		640000000
+#define OV5693_LINK_FREQ_400MHZ		400000000
 /* pixel_rate = link_freq * 2 * nr_of_lanes / bits_per_sample
  * To avoid integer overflow, dividing by bits_per_sample first.
  */
-#define OV5693_PIXEL_RATE		(OV5693_LINK_FREQ_640MHZ / 10) * 2 * 2
+#define OV5693_PIXEL_RATE		(OV5693_LINK_FREQ_400MHZ / 10) * 2 * 2
 static const s64 link_freq_menu_items[] = {
-	OV5693_LINK_FREQ_640MHZ
+	OV5693_LINK_FREQ_400MHZ
 };
 
 #define OV5693_NUM_SUPPLIES             2

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -270,7 +270,17 @@ struct ov5693_device {
 
 	bool has_vcm;
 
-	struct v4l2_ctrl *hblank;
+	struct ov5693_v4l2_ctrls {
+		struct v4l2_ctrl *link_freq;
+		struct v4l2_ctrl *pixel_rate;
+		struct v4l2_ctrl *exposure;
+		struct v4l2_ctrl *analogue_gain;
+		struct v4l2_ctrl *digital_gain;
+		struct v4l2_ctrl *hflip;
+		struct v4l2_ctrl *vflip;
+		struct v4l2_ctrl *hblank;
+	} ctrls;
+
 };
 
 enum ov5693_tok_type {

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -37,68 +37,23 @@
  */
 #define ENABLE_NON_PREVIEW	1
 
-#define OV5693_POWER_UP_RETRY_NUM 5
-
 /* Defines for register writes and register array processing */
-#define I2C_MSG_LENGTH		0x2
-#define I2C_RETRY_COUNT		5
-
-#define OV5693_FOCAL_LENGTH_NUM	334	/*3.34mm*/
-#define OV5693_FOCAL_LENGTH_DEM	100
-#define OV5693_F_NUMBER_DEFAULT_NUM	24
-#define OV5693_F_NUMBER_DEM	10
+#define I2C_MSG_LENGTH         0x2
 
 #define MAX_FMTS		1
 
-/* sensor_mode_data read_mode adaptation */
-#define OV5693_READ_MODE_BINNING_ON	0x0400
-#define OV5693_READ_MODE_BINNING_OFF	0x00
-#define OV5693_INTEGRATION_TIME_MARGIN	8
-
-#define OV5693_MAX_EXPOSURE_VALUE	0xFFF1
-#define OV5693_MAX_GAIN_VALUE		0xFF
-
-/*
- * focal length bits definition:
- * bits 31-16: numerator, bits 15-0: denominator
- */
-#define OV5693_FOCAL_LENGTH_DEFAULT 0x1B70064
-
-/*
- * current f-number bits definition:
- * bits 31-16: numerator, bits 15-0: denominator
- */
-#define OV5693_F_NUMBER_DEFAULT 0x18000a
-
-/*
- * f-number range bits definition:
- * bits 31-24: max f-number numerator
- * bits 23-16: max f-number denominator
- * bits 15-8: min f-number numerator
- * bits 7-0: min f-number denominator
- */
-#define OV5693_F_NUMBER_RANGE 0x180a180a
 #define OV5693_ID	0x5690
 
-#define OV5693_FINE_INTG_TIME_MIN 0
-#define OV5693_FINE_INTG_TIME_MAX_MARGIN 0
-#define OV5693_COARSE_INTG_TIME_MIN 1
-#define OV5693_COARSE_INTG_TIME_MAX_MARGIN 6
-
-#define OV5693_BIN_FACTOR_MAX 4
 /*
  * OV5693 System control registers
  */
-#define OV5693_SW_SLEEP				0x0100
 #define OV5693_SW_RESET				0x0103
 #define OV5693_SW_STREAM			0x0100
 
 #define OV5693_SC_CMMN_CHIP_ID_H		0x300A
 #define OV5693_SC_CMMN_CHIP_ID_L		0x300B
-#define OV5693_SC_CMMN_SCCB_ID			0x300C
 #define OV5693_SC_CMMN_SUB_ID			0x302A /* process, version*/
-/*Bit[7:4] Group control, Bit[3:0] Group ID*/
-#define OV5693_GROUP_ACCESS			0x3208
+
 /*
 *Bit[3:0] Bit[19:16] of exposure,
 *remaining 16 bits lies in Reg0x3501&Reg0x3502
@@ -110,18 +65,6 @@
 #define OV5693_AGC_H				0x350A
 #define OV5693_AGC_L				0x350B /*Bit[7:0] of gain*/
 
-#define OV5693_HORIZONTAL_START_H		0x3800 /*Bit[11:8]*/
-#define OV5693_HORIZONTAL_START_L		0x3801 /*Bit[7:0]*/
-#define OV5693_VERTICAL_START_H			0x3802 /*Bit[11:8]*/
-#define OV5693_VERTICAL_START_L			0x3803 /*Bit[7:0]*/
-#define OV5693_HORIZONTAL_END_H			0x3804 /*Bit[11:8]*/
-#define OV5693_HORIZONTAL_END_L			0x3805 /*Bit[7:0]*/
-#define OV5693_VERTICAL_END_H			0x3806 /*Bit[11:8]*/
-#define OV5693_VERTICAL_END_L			0x3807 /*Bit[7:0]*/
-#define OV5693_HORIZONTAL_OUTPUT_SIZE_H		0x3808 /*Bit[3:0]*/
-#define OV5693_HORIZONTAL_OUTPUT_SIZE_L		0x3809 /*Bit[7:0]*/
-#define OV5693_VERTICAL_OUTPUT_SIZE_H		0x380a /*Bit[3:0]*/
-#define OV5693_VERTICAL_OUTPUT_SIZE_L		0x380b /*Bit[7:0]*/
 /*High 8-bit, and low 8-bit HTS address is 0x380d*/
 #define OV5693_TIMING_HTS_H			0x380C
 /*High 8-bit, and low 8-bit HTS address is 0x380d*/
@@ -140,34 +83,6 @@
 
 #define OV5693_START_STREAMING			0x01
 #define OV5693_STOP_STREAMING			0x00
-
-#define VCM_ADDR           0x0c
-#define VCM_CODE_MSB       0x04
-
-#define OV5693_INVALID_CONFIG	0xffffffff
-
-#define OV5693_VCM_SLEW_STEP			0x30F0
-#define OV5693_VCM_SLEW_STEP_MAX		0x7
-#define OV5693_VCM_SLEW_STEP_MASK		0x7
-#define OV5693_VCM_CODE				0x30F2
-#define OV5693_VCM_SLEW_TIME			0x30F4
-#define OV5693_VCM_SLEW_TIME_MAX		0xffff
-#define OV5693_VCM_ENABLE			0x8000
-
-#define OV5693_VCM_MAX_FOCUS_NEG       -1023
-#define OV5693_VCM_MAX_FOCUS_POS       1023
-
-#define DLC_ENABLE 1
-#define DLC_DISABLE 0
-#define VCM_PROTECTION_OFF     0xeca3
-#define VCM_PROTECTION_ON      0xdc51
-#define VCM_DEFAULT_S 0x0
-#define vcm_step_s(a) (u8)(a & 0xf)
-#define vcm_step_mclk(a) (u8)((a >> 4) & 0x3)
-#define vcm_dlc_mclk(dlc, mclk) (u16)((dlc << 3) | mclk | 0xa104)
-#define vcm_tsrc(tsrc) (u16)(tsrc << 3 | 0xf200)
-#define vcm_val(data, s) (u16)(data << 4 | s)
-#define DIRECT_VCM vcm_dlc_mclk(0, 0)
 
 /* Defines for OTP Data Registers */
 #define OV5693_FRAME_OFF_NUM		0x4202

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -241,14 +241,15 @@ enum vcm_type {
  * ov5693 device structure.
  */
 struct ov5693_device {
-	struct i2c_client *i2c_client;
+	struct i2c_client *client;
 	struct v4l2_subdev sd;
 	struct media_pad pad;
 	struct v4l2_mbus_framefmt format;
-	struct mutex input_lock;
+	struct mutex lock;
 	struct v4l2_ctrl_handler ctrl_handler;
 
         struct gpio_desc *reset;
+	struct gpio_desc *powerdown;
         struct gpio_desc *indicator_led;
         struct regulator_bulk_data supplies[OV5693_NUM_SUPPLIES];
 	struct clk *clk;

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -131,6 +131,8 @@
 /*High 8-bit, and low 8-bit HTS address is 0x380f*/
 #define OV5693_TIMING_VTS_L			0x380f
 
+#define OV5693_TIMING_MAX_VTS			0xffff
+
 #define OV5693_MWB_RED_GAIN_H			0x3400
 #define OV5693_MWB_GREEN_GAIN_H			0x3402
 #define OV5693_MWB_BLUE_GAIN_H			0x3404
@@ -279,6 +281,7 @@ struct ov5693_device {
 		struct v4l2_ctrl *hflip;
 		struct v4l2_ctrl *vflip;
 		struct v4l2_ctrl *hblank;
+		struct v4l2_ctrl *vblank;
 	} ctrls;
 
 };

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -256,6 +256,7 @@ struct ov5693_device {
 
 	/* Current mode */
 	const struct ov5693_resolution *mode;
+	bool streaming;
 
 	struct camera_sensor_platform_data *platform_data;
 	ktime_t timestamp_t_focus_abs;

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -474,34 +474,7 @@ static struct ov5693_reg const ov5693_global_setting[] = {
 };
 
 #if ENABLE_NON_PREVIEW
-/*
- * 654x496 30fps 17ms VBlanking 2lane 10Bit (Scaling)
- */
-static struct ov5693_reg const ov5693_654x496[] = {
-	{OV5693_8BIT, 0x3501, 0x3d},
-	{OV5693_8BIT, 0x3502, 0x00},
-	{OV5693_8BIT, 0x3708, 0xe6},
-	{OV5693_8BIT, 0x3709, 0xc7},
-	{OV5693_8BIT, 0x3803, 0x00},
-	{OV5693_8BIT, 0x3806, 0x07},
-	{OV5693_8BIT, 0x3807, 0xa3},
-	{OV5693_8BIT, 0x3808, 0x02},
-	{OV5693_8BIT, 0x3809, 0x90},
-	{OV5693_8BIT, 0x380a, 0x01},
-	{OV5693_8BIT, 0x380b, 0xf0},
-	{OV5693_8BIT, 0x380c, 0x0a},
-	{OV5693_8BIT, 0x380d, 0x80},
-	{OV5693_8BIT, 0x380e, 0x07},
-	{OV5693_8BIT, 0x380f, 0xc0},
-	{OV5693_8BIT, 0x3811, 0x08},
-	{OV5693_8BIT, 0x3813, 0x02},
-	{OV5693_8BIT, 0x3814, 0x31},
-	{OV5693_8BIT, 0x3815, 0x31},
-	{OV5693_8BIT, 0x3820, 0x04},
-	{OV5693_8BIT, 0x3821, 0x1f},
-	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_TOK_TERM, 0, 0}
-};
+
 
 /*
  * 1296x976 30fps 17ms VBlanking 2lane 10Bit (Scaling)
@@ -661,61 +634,9 @@ static struct ov5693_reg const ov5693_736x496[] = {
 #endif
 
 /*
-static struct ov5693_reg const ov5693_736x496[] = {
-	{OV5693_8BIT, 0x3501, 0x7b},
-	{OV5693_8BIT, 0x3502, 0x00},
-	{OV5693_8BIT, 0x3708, 0xe6},
-	{OV5693_8BIT, 0x3709, 0xc3},
-	{OV5693_8BIT, 0x3803, 0x00},
-	{OV5693_8BIT, 0x3806, 0x07},
-	{OV5693_8BIT, 0x3807, 0xa3},
-	{OV5693_8BIT, 0x3808, 0x02},
-	{OV5693_8BIT, 0x3809, 0xe0},
-	{OV5693_8BIT, 0x380a, 0x01},
-	{OV5693_8BIT, 0x380b, 0xf0},
-	{OV5693_8BIT, 0x380c, 0x0d},
-	{OV5693_8BIT, 0x380d, 0xb0},
-	{OV5693_8BIT, 0x380e, 0x05},
-	{OV5693_8BIT, 0x380f, 0xf2},
-	{OV5693_8BIT, 0x3811, 0x08},
-	{OV5693_8BIT, 0x3813, 0x02},
-	{OV5693_8BIT, 0x3814, 0x31},
-	{OV5693_8BIT, 0x3815, 0x31},
-	{OV5693_8BIT, 0x3820, 0x01},
-	{OV5693_8BIT, 0x3821, 0x1f},
-	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_TOK_TERM, 0, 0}
-};
-*/
-/*
  * 976x556 30fps 8.8ms VBlanking 2lane 10Bit (Scaling)
  */
 #if ENABLE_NON_PREVIEW
-static struct ov5693_reg const ov5693_976x556[] = {
-	{OV5693_8BIT, 0x3501, 0x7b},
-	{OV5693_8BIT, 0x3502, 0x00},
-	{OV5693_8BIT, 0x3708, 0xe2},
-	{OV5693_8BIT, 0x3709, 0xc3},
-	{OV5693_8BIT, 0x3803, 0xf0},
-	{OV5693_8BIT, 0x3806, 0x06},
-	{OV5693_8BIT, 0x3807, 0xa7},
-	{OV5693_8BIT, 0x3808, 0x03},
-	{OV5693_8BIT, 0x3809, 0xd0},
-	{OV5693_8BIT, 0x380a, 0x02},
-	{OV5693_8BIT, 0x380b, 0x2C},
-	{OV5693_8BIT, 0x380c, 0x0a},
-	{OV5693_8BIT, 0x380d, 0x80},
-	{OV5693_8BIT, 0x380e, 0x07},
-	{OV5693_8BIT, 0x380f, 0xc0},
-	{OV5693_8BIT, 0x3811, 0x10},
-	{OV5693_8BIT, 0x3813, 0x02},
-	{OV5693_8BIT, 0x3814, 0x11},
-	{OV5693_8BIT, 0x3815, 0x11},
-	{OV5693_8BIT, 0x3820, 0x00},
-	{OV5693_8BIT, 0x3821, 0x1e},
-	{OV5693_8BIT, 0x5002, 0x80},
-	{OV5693_TOK_TERM, 0, 0}
-};
 
 /*DS from 2624x1492*/
 static struct ov5693_reg const ov5693_1296x736[] = {
@@ -782,40 +703,6 @@ static struct ov5693_reg const ov5693_1636p_30fps[] = {
 };
 #endif
 
-static struct ov5693_reg const ov5693_1616x1216_30fps[] = {
-	{OV5693_8BIT, 0x3501, 0x7b},
-	{OV5693_8BIT, 0x3502, 0x80},
-	{OV5693_8BIT, 0x3708, 0xe2},
-	{OV5693_8BIT, 0x3709, 0xc3},
-	{OV5693_8BIT, 0x3800, 0x00},	/*{3800,3801} Array X start*/
-	{OV5693_8BIT, 0x3801, 0x08},	/* 04 //{3800,3801} Array X start*/
-	{OV5693_8BIT, 0x3802, 0x00},	/*{3802,3803} Array Y start*/
-	{OV5693_8BIT, 0x3803, 0x04},	/* 00  //{3802,3803} Array Y start*/
-	{OV5693_8BIT, 0x3804, 0x0a},	/*{3804,3805} Array X end*/
-	{OV5693_8BIT, 0x3805, 0x37},	/* 3b  //{3804,3805} Array X end*/
-	{OV5693_8BIT, 0x3806, 0x07},	/*{3806,3807} Array Y end*/
-	{OV5693_8BIT, 0x3807, 0x9f},	/* a3  //{3806,3807} Array Y end*/
-	{OV5693_8BIT, 0x3808, 0x06},	/*{3808,3809} Final output H size*/
-	{OV5693_8BIT, 0x3809, 0x50},	/*{3808,3809} Final output H size*/
-	{OV5693_8BIT, 0x380a, 0x04},	/*{380a,380b} Final output V size*/
-	{OV5693_8BIT, 0x380b, 0xc0},	/*{380a,380b} Final output V size*/
-	{OV5693_8BIT, 0x380c, 0x0a},	/*{380c,380d} HTS*/
-	{OV5693_8BIT, 0x380d, 0x80},	/*{380c,380d} HTS*/
-	{OV5693_8BIT, 0x380e, 0x07},	/*{380e,380f} VTS*/
-	{OV5693_8BIT, 0x380f, 0xc0},	/* bc	//{380e,380f} VTS*/
-	{OV5693_8BIT, 0x3810, 0x00},	/*{3810,3811} windowing X offset*/
-	{OV5693_8BIT, 0x3811, 0x10},	/*{3810,3811} windowing X offset*/
-	{OV5693_8BIT, 0x3812, 0x00},	/*{3812,3813} windowing Y offset*/
-	{OV5693_8BIT, 0x3813, 0x06},	/*{3812,3813} windowing Y offset*/
-	{OV5693_8BIT, 0x3814, 0x11},	/*X subsample control*/
-	{OV5693_8BIT, 0x3815, 0x11},	/*Y subsample control*/
-	{OV5693_8BIT, 0x3820, 0x00},	/*FLIP/Binnning control*/
-	{OV5693_8BIT, 0x3821, 0x1e},	/*MIRROR control*/
-	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_8BIT, 0x5041, 0x84},
-	{OV5693_TOK_TERM, 0, 0}
-};
-
 /*
  * 1940x1096 30fps 8.8ms VBlanking 2lane 10bit (Scaling)
  */
@@ -878,37 +765,6 @@ static struct ov5693_reg const ov5693_2592x1456_30fps[] = {
 };
 #endif
 
-static struct ov5693_reg const ov5693_2576x1456_30fps[] = {
-	{OV5693_8BIT, 0x3501, 0x7b},
-	{OV5693_8BIT, 0x3502, 0x00},
-	{OV5693_8BIT, 0x3708, 0xe2},
-	{OV5693_8BIT, 0x3709, 0xc3},
-	{OV5693_8BIT, 0x3800, 0x00},
-	{OV5693_8BIT, 0x3801, 0x00},
-	{OV5693_8BIT, 0x3802, 0x00},
-	{OV5693_8BIT, 0x3803, 0xf0},
-	{OV5693_8BIT, 0x3804, 0x0a},
-	{OV5693_8BIT, 0x3805, 0x3f},
-	{OV5693_8BIT, 0x3806, 0x06},
-	{OV5693_8BIT, 0x3807, 0xa4},
-	{OV5693_8BIT, 0x3808, 0x0a},
-	{OV5693_8BIT, 0x3809, 0x10},
-	{OV5693_8BIT, 0x380a, 0x05},
-	{OV5693_8BIT, 0x380b, 0xb0},
-	{OV5693_8BIT, 0x380c, 0x0a},
-	{OV5693_8BIT, 0x380d, 0x80},
-	{OV5693_8BIT, 0x380e, 0x07},
-	{OV5693_8BIT, 0x380f, 0xc0},
-	{OV5693_8BIT, 0x3811, 0x18},
-	{OV5693_8BIT, 0x3813, 0x00},
-	{OV5693_8BIT, 0x3814, 0x11},
-	{OV5693_8BIT, 0x3815, 0x11},
-	{OV5693_8BIT, 0x3820, 0x00},
-	{OV5693_8BIT, 0x3821, 0x1e},
-	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_TOK_TERM, 0, 0}
-};
-
 /*
  * 2592x1944 30fps 0.6ms VBlanking 2lane 10Bit
  */
@@ -936,49 +792,6 @@ static struct ov5693_reg const ov5693_2592x1944_30fps[] = {
 	{OV5693_8BIT, 0x3820, 0x00},
 	{OV5693_8BIT, 0x3821, 0x1e},
 	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_TOK_TERM, 0, 0}
-};
-#endif
-
-/*
- * 11:9 Full FOV Output, expected FOV Res: 2346x1920
- * ISP Effect Res: 1408x1152
- * Sensor out: 1424x1168, DS From: 2380x1952
- *
- * WA: Left Offset: 8, Hor scal: 64
- */
-#if ENABLE_NON_PREVIEW
-static struct ov5693_reg const ov5693_1424x1168_30fps[] = {
-	{OV5693_8BIT, 0x3501, 0x3b}, /* long exposure[15:8] */
-	{OV5693_8BIT, 0x3502, 0x80}, /* long exposure[7:0] */
-	{OV5693_8BIT, 0x3708, 0xe2},
-	{OV5693_8BIT, 0x3709, 0xc3},
-	{OV5693_8BIT, 0x3800, 0x00}, /* TIMING_X_ADDR_START */
-	{OV5693_8BIT, 0x3801, 0x50}, /* 80 */
-	{OV5693_8BIT, 0x3802, 0x00}, /* TIMING_Y_ADDR_START */
-	{OV5693_8BIT, 0x3803, 0x02}, /* 2 */
-	{OV5693_8BIT, 0x3804, 0x09}, /* TIMING_X_ADDR_END */
-	{OV5693_8BIT, 0x3805, 0xdd}, /* 2525 */
-	{OV5693_8BIT, 0x3806, 0x07}, /* TIMING_Y_ADDR_END */
-	{OV5693_8BIT, 0x3807, 0xa1}, /* 1953 */
-	{OV5693_8BIT, 0x3808, 0x05}, /* TIMING_X_OUTPUT_SIZE */
-	{OV5693_8BIT, 0x3809, 0x90}, /* 1424 */
-	{OV5693_8BIT, 0x380a, 0x04}, /* TIMING_Y_OUTPUT_SIZE */
-	{OV5693_8BIT, 0x380b, 0x90}, /* 1168 */
-	{OV5693_8BIT, 0x380c, 0x0a}, /* TIMING_HTS */
-	{OV5693_8BIT, 0x380d, 0x80},
-	{OV5693_8BIT, 0x380e, 0x07}, /* TIMING_VTS */
-	{OV5693_8BIT, 0x380f, 0xc0},
-	{OV5693_8BIT, 0x3810, 0x00}, /* TIMING_ISP_X_WIN */
-	{OV5693_8BIT, 0x3811, 0x02}, /* 2 */
-	{OV5693_8BIT, 0x3812, 0x00}, /* TIMING_ISP_Y_WIN */
-	{OV5693_8BIT, 0x3813, 0x00}, /* 0 */
-	{OV5693_8BIT, 0x3814, 0x11}, /* TIME_X_INC */
-	{OV5693_8BIT, 0x3815, 0x11}, /* TIME_Y_INC */
-	{OV5693_8BIT, 0x3820, 0x00},
-	{OV5693_8BIT, 0x3821, 0x1e},
-	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_8BIT, 0x5041, 0x84}, /* scale is auto enabled */
 	{OV5693_TOK_TERM, 0, 0}
 };
 #endif
@@ -1021,173 +834,6 @@ static struct ov5693_reg const ov5693_736x496_30fps[] = {
 	{OV5693_8BIT, 0x5041, 0x84}, /* scale is auto enabled */
 	{OV5693_TOK_TERM, 0, 0}
 };
-
-static struct ov5693_reg const ov5693_2576x1936_30fps[] = {
-	{OV5693_8BIT, 0x3501, 0x7b},
-	{OV5693_8BIT, 0x3502, 0x00},
-	{OV5693_8BIT, 0x3708, 0xe2},
-	{OV5693_8BIT, 0x3709, 0xc3},
-	{OV5693_8BIT, 0x3803, 0x00},
-	{OV5693_8BIT, 0x3806, 0x07},
-	{OV5693_8BIT, 0x3807, 0xa3},
-	{OV5693_8BIT, 0x3808, 0x0a},
-	{OV5693_8BIT, 0x3809, 0x10},
-	{OV5693_8BIT, 0x380a, 0x07},
-	{OV5693_8BIT, 0x380b, 0x90},
-	{OV5693_8BIT, 0x380c, 0x0a},
-	{OV5693_8BIT, 0x380d, 0x80},
-	{OV5693_8BIT, 0x380e, 0x07},
-	{OV5693_8BIT, 0x380f, 0xc0},
-	{OV5693_8BIT, 0x3811, 0x18},
-	{OV5693_8BIT, 0x3813, 0x00},
-	{OV5693_8BIT, 0x3814, 0x11},
-	{OV5693_8BIT, 0x3815, 0x11},
-	{OV5693_8BIT, 0x3820, 0x00},
-	{OV5693_8BIT, 0x3821, 0x1e},
-	{OV5693_8BIT, 0x5002, 0x00},
-	{OV5693_TOK_TERM, 0, 0}
-};
-
-static struct ov5693_resolution ov5693_res_preview[] = {
-	{
-		.desc = "ov5693_736x496_30fps",
-		.width = 736,
-		.height = 496,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_736x496_30fps,
-	},
-	{
-		.desc = "ov5693_1616x1216_30fps",
-		.width = 1616,
-		.height = 1216,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_1616x1216_30fps,
-	},
-	{
-		.desc = "ov5693_5M_30fps",
-		.width = 2576,
-		.height = 1456,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_2576x1456_30fps,
-	},
-	{
-		.desc = "ov5693_5M_30fps",
-		.width = 2576,
-		.height = 1936,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_2576x1936_30fps,
-	},
-};
-
-#define N_RES_PREVIEW (ARRAY_SIZE(ov5693_res_preview))
-
-/*
- * Disable non-preview configurations until the configuration selection is
- * improved.
- */
-#if ENABLE_NON_PREVIEW
-struct ov5693_resolution ov5693_res_still[] = {
-	{
-		.desc = "ov5693_736x496_30fps",
-		.width = 736,
-		.height = 496,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_736x496_30fps,
-	},
-	{
-		.desc = "ov5693_1424x1168_30fps",
-		.width = 1424,
-		.height = 1168,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_1424x1168_30fps,
-	},
-	{
-		.desc = "ov5693_1616x1216_30fps",
-		.width = 1616,
-		.height = 1216,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_1616x1216_30fps,
-	},
-	{
-		.desc = "ov5693_5M_30fps",
-		.width = 2592,
-		.height = 1456,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_2592x1456_30fps,
-	},
-	{
-		.desc = "ov5693_5M_30fps",
-		.width = 2592,
-		.height = 1944,
-		.pix_clk_freq = 160,
-		.fps = 30,
-		.used = 0,
-		.pixels_per_line = 2688,
-		.lines_per_frame = 1984,
-		.bin_factor_x = 1,
-		.bin_factor_y = 1,
-		.bin_mode = 0,
-		.regs = ov5693_2592x1944_30fps,
-	},
-};
-
-#define N_RES_STILL (ARRAY_SIZE(ov5693_res_still))
 
 struct ov5693_resolution ov5693_res_video[] = {
 	{
@@ -1343,4 +989,3 @@ struct ov5693_resolution ov5693_res_video[] = {
 
 static struct ov5693_resolution *ov5693_res = ov5693_res_video;
 static unsigned long N_RES = N_RES_VIDEO;
-#endif

--- a/drivers/media/i2c/ov5693.h
+++ b/drivers/media/i2c/ov5693.h
@@ -100,6 +100,8 @@
 #define OV5693_OTP_READ_ONETIME		16
 #define OV5693_OTP_MODE_READ		1
 
+#define OV5693_XVCLK_FREQ		19200000
+
 /* link freq and pixel rate required for IPU3 */
 #define OV5693_LINK_FREQ_400MHZ		400000000
 /* pixel_rate = link_freq * 2 * nr_of_lanes / bits_per_sample


### PR DESCRIPTION
Hello

Here's a long batch of updates to the ov5693 driver. It's mostly tidying, with some functional changes:

- pm_runtime support replacing the existing power functions
- Fixed control setting (which previously was broken)
- Added vblank control (needed in latest versions of libcamera)

I'm planning on working on this quite a lot (meaning there'll be more to come), but I think @fabwu at least was too, so wanted to update you with what I'd done so far so we're not duplicating effort, and also because without the vblank control the driver won't work for anyone using latest versions of libcamera (already the cause of comments on #91)

Note that with later versions of libcamera this will now seem broken, when you stream in qcam it'll insta-max exposure which means the image will be white and FPS about 1-2 maximum. That's due to libcamera maxing them (which previously just wasn't being applied because nothing in the driver was doing it). You can use `sudo v4l2-ctl -d /dev/v4l-subdevn --set-ctrl exposure=123` to drop it to a reasonable value (which'll fix the FPS too). Though note that without a [recent patch](https://lists.libcamera.org/pipermail/libcamera-devel/2021-February/017258.html), it'll re-max it 2 frames later, so it's a bit annoying.