### PR TITLE
[5.11] Update IPTS based on module

### DIFF
--- a/drivers/misc/ipts/control.h
+++ b/drivers/misc/ipts/control.h
@@ -15,6 +15,8 @@
 
 int ipts_control_send(struct ipts_context *ipts, u32 cmd, void *payload,
 		      size_t size);
+int ipts_control_send_feedback(struct ipts_context *ipts, u32 buffer);
+int ipts_control_set_feature(struct ipts_context *ipts, u8 report, u8 value);
 int ipts_control_start(struct ipts_context *ipts);
 int ipts_control_restart(struct ipts_context *ipts);
 int ipts_control_stop(struct ipts_context *ipts);

--- a/drivers/misc/ipts/mei.c
+++ b/drivers/misc/ipts/mei.c
@@ -9,8 +9,8 @@
 #include <linux/delay.h>
 #include <linux/dma-mapping.h>
 #include <linux/mei_cl_bus.h>
-#include <linux/module.h>
 #include <linux/mod_devicetable.h>
+#include <linux/module.h>
 #include <linux/slab.h>
 
 #include "context.h"
@@ -65,10 +65,19 @@ static int ipts_mei_probe(struct mei_cl_device *cldev,
 
 static int ipts_mei_remove(struct mei_cl_device *cldev)
 {
+	int i;
 	struct ipts_context *ipts = mei_cldev_get_drvdata(cldev);
 
-	mei_cldev_disable(cldev);
 	ipts_control_stop(ipts);
+
+	for (i = 0; i < 20; i++) {
+		if (ipts->status == IPTS_HOST_STATUS_STOPPED)
+			break;
+
+		msleep(25);
+	}
+
+	mei_cldev_disable(cldev);
 	kfree(ipts);
 
 	return 0;

--- a/drivers/misc/ipts/protocol.h
+++ b/drivers/misc/ipts/protocol.h
@@ -141,6 +141,11 @@ enum ipts_status {
  */
 #define IPTS_BUFFERS 16
 
+/*
+ * The special buffer ID that is used for direct host2me feedback.
+ */
+#define IPTS_HOST2ME_BUFFER IPTS_BUFFERS
+
 /**
  * enum ipts_mode - Operation mode for IPTS hardware
  * @IPTS_MODE_SINGLETOUCH: Fallback that supports only one finger and no stylus.
@@ -218,6 +223,56 @@ struct ipts_feedback_cmd {
 } __packed;
 
 /**
+ * enum ipts_feedback_cmd_type - Commands that can be executed on the sensor through feedback.
+ */
+enum ipts_feedback_cmd_type {
+	IPTS_FEEDBACK_CMD_TYPE_NONE = 0,
+	IPTS_FEEDBACK_CMD_TYPE_SOFT_RESET = 1,
+	IPTS_FEEDBACK_CMD_TYPE_GOTO_ARMED = 2,
+	IPTS_FEEDBACK_CMD_TYPE_GOTO_SENSING = 3,
+	IPTS_FEEDBACK_CMD_TYPE_GOTO_SLEEP = 4,
+	IPTS_FEEDBACK_CMD_TYPE_GOTO_DOZE = 5,
+	IPTS_FEEDBACK_CMD_TYPE_HARD_RESET = 6,
+};
+
+/**
+ * enum ipts_feedback_data_type - Describes the data that a feedback buffer contains.
+ * @IPTS_FEEDBACK_DATA_TYPE_VENDOR:        The buffer contains vendor specific feedback.
+ * @IPTS_FEEDBACK_DATA_TYPE_SET_FEATURES:  The buffer contains a HID set features command.
+ * @IPTS_FEEDBACK_DATA_TYPE_GET_FEATURES:  The buffer contains a HID get features command.
+ * @IPTS_FEEDBACK_DATA_TYPE_OUTPUT_REPORT: The buffer contains a HID output report.
+ * @IPTS_FEEDBACK_DATA_TYPE_STORE_DATA:    The buffer contains calibration data for the sensor.
+ */
+enum ipts_feedback_data_type {
+	IPTS_FEEDBACK_DATA_TYPE_VENDOR = 0,
+	IPTS_FEEDBACK_DATA_TYPE_SET_FEATURES = 1,
+	IPTS_FEEDBACK_DATA_TYPE_GET_FEATURES = 2,
+	IPTS_FEEDBACK_DATA_TYPE_OUTPUT_REPORT = 3,
+	IPTS_FEEDBACK_DATA_TYPE_STORE_DATA = 4,
+};
+
+/**
+ * struct ipts_feedback_buffer - The contents of an IPTS feedback buffer.
+ * @cmd_type: A command that should be executed on the sensor.
+ * @size: The size of the payload to be written.
+ * @buffer: The ID of the buffer that contains this feedback data.
+ * @protocol: The protocol version of the EDS.
+ * @data_type: The type of payload that the buffer contains.
+ * @spi_offset: The offset at which to write the payload data.
+ * @payload: Payload for the feedback command, or 0 if no payload is sent.
+ */
+struct ipts_feedback_buffer {
+	enum ipts_feedback_cmd_type cmd_type;
+	u32 size;
+	u32 buffer;
+	u32 protocol;
+	enum ipts_feedback_data_type data_type;
+	u32 spi_offset;
+	u8 reserved[40];
+	u8 payload[];
+} __packed;
+
+/**
  * enum ipts_reset_type - Possible ways of resetting the touch sensor
  * @IPTS_RESET_TYPE_HARD: Perform hardware reset using GPIO pin.
  * @IPTS_RESET_TYPE_SOFT: Perform software reset using SPI interface.
@@ -267,6 +322,14 @@ struct ipts_get_device_info_rsp {
 	enum ipts_mode mode;
 	u8 max_contacts;
 	u8 reserved[19];
+} __packed;
+
+/**
+ * struct ipts_feedback_rsp - Payload for the FEEDBACK response.
+ * @buffer: The buffer that has received feedback.
+ */
+struct ipts_feedback_rsp {
+	u32 buffer;
 } __packed;
 
 /**

--- a/drivers/misc/ipts/uapi.c
+++ b/drivers/misc/ipts/uapi.c
@@ -7,11 +7,11 @@
  */
 
 #include <linux/cdev.h>
+#include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/fs.h>
-#include <linux/delay.h>
-#include <linux/uaccess.h>
 #include <linux/types.h>
+#include <linux/uaccess.h>
 
 #include "context.h"
 #include "control.h"
@@ -96,17 +96,14 @@ static long ipts_uapi_ioctl_send_feedback(struct ipts_context *ipts,
 					  struct file *file)
 {
 	int ret;
-	struct ipts_feedback_cmd cmd;
+	u32 buffer;
 
 	if (!ipts || ipts->status != IPTS_HOST_STATUS_STARTED)
 		return -ENODEV;
 
-	memset(&cmd, 0, sizeof(struct ipts_feedback_cmd));
-	cmd.buffer = MINOR(file->f_path.dentry->d_inode->i_rdev);
+	buffer = MINOR(file->f_path.dentry->d_inode->i_rdev);
 
-	ret = ipts_control_send(ipts, IPTS_CMD_FEEDBACK, &cmd,
-				sizeof(struct ipts_feedback_cmd));
-
+	ret = ipts_control_send_feedback(ipts, buffer);
 	if (ret)
 		return -EFAULT;
 

--- a/drivers/misc/mei/init.c
+++ b/drivers/misc/mei/init.c
@@ -302,10 +302,10 @@ void mei_stop(struct mei_device *dev)
 {
 	dev_dbg(dev->dev, "stopping the device.\n");
 
+	mei_cl_bus_remove_devices(dev);
 	mutex_lock(&dev->device_lock);
 	mei_set_devstate(dev, MEI_DEV_POWER_DOWN);
 	mutex_unlock(&dev->device_lock);
-	mei_cl_bus_remove_devices(dev);
 
 	mei_cancel_work(dev);
 


### PR DESCRIPTION
With the last set of changes to ipts I introduced a bug that only seems to surface on some devices. If the buffer addresses are not cleared during suspend, the IPTS device will not restart after resuming, because it presumably tries to write to invalid buffers now. The only way to solve this is to send `CLEAR_MEM_WINDOW` during shutdown, which means we have to readd the MEI bus patch that I tried to get rid of.

Another change is that the module will now send feedback for every buffer during shutdown. The reason for this is that `CLEAR_MEM_WINDOW` will fail with a timeout error if there is still unprocessed data around, which triggers the bug described above.

The third big change is that this includes the code to enable multitouch mode on gen7 devices. Because its only tested on a SP7 so far, and of course iptsd doesnt support the new format yet, this is hidden behind the `gen7mt` module option.