### PR TITLE
Enable wifi powersaving by default again

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
@@ -451,13 +451,6 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
 		return -EPERM;
 	}
 
-	if (ps_mode)
-		mwifiex_dbg(priv->adapter, MSG,
-			    "Enabling ps_mode, disable if unstable.\n");
-	else
-		mwifiex_dbg(priv->adapter, MSG,
-			    "Disabling ps_mode.\n");
-
 	return mwifiex_drv_set_power(priv, &ps_mode);
 }
 

--- a/drivers/net/wireless/marvell/mwifiex/cfg80211.c
+++ b/drivers/net/wireless/marvell/mwifiex/cfg80211.c
@@ -25,11 +25,6 @@
 static char *reg_alpha2;
 module_param(reg_alpha2, charp, 0);
 
-static bool allow_ps_mode;
-module_param(allow_ps_mode, bool, 0644);
-MODULE_PARM_DESC(allow_ps_mode,
-		 "allow WiFi power management to be enabled. (default: disallowed)");
-
 static const struct ieee80211_iface_limit mwifiex_ap_sta_limits[] = {
 	{
 		.max = MWIFIEX_MAX_BSS_NUM,
@@ -439,17 +434,6 @@ mwifiex_cfg80211_set_power_mgmt(struct wiphy *wiphy,
 			    "info: ignore timeout value for IEEE Power Save\n");
 
 	ps_mode = enabled;
-
-	/* Allow ps_mode to be enabled only when allow_ps_mode is true */
-	if (ps_mode && !allow_ps_mode) {
-		mwifiex_dbg(priv->adapter, MSG,
-			    "Enabling ps_mode disallowed by modparam\n");
-
-		/* Return -EPERM to inform userspace tools that setting
-		 * power_save to be enabled is not permitted.
-		 */
-		return -EPERM;
-	}
 
 	return mwifiex_drv_set_power(priv, &ps_mode);
 }

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -183,11 +183,6 @@ static const struct mwifiex_pcie_device mwifiex_pcie8997 = {
 	.can_ext_scan = true,
 };
 
-static bool enable_device_dump;
-module_param(enable_device_dump, bool, 0644);
-MODULE_PARM_DESC(enable_device_dump,
-		 "enable device_dump (default: disabled)");
-
 static const struct of_device_id mwifiex_pcie_of_match_table[] = {
 	{ .compatible = "pci11ab,2b42" },
 	{ .compatible = "pci1b4b,2b42" },
@@ -2973,12 +2968,6 @@ static void mwifiex_pcie_fw_dump(struct mwifiex_adapter *adapter)
 
 static void mwifiex_pcie_device_dump_work(struct mwifiex_adapter *adapter)
 {
-	if (!enable_device_dump) {
-		mwifiex_dbg(adapter, MSG,
-			    "device_dump is disabled by module parameter\n");
-		return;
-	}
-
 	adapter->devdump_data = vzalloc(MWIFIEX_FW_DUMP_SIZE);
 	if (!adapter->devdump_data) {
 		mwifiex_dbg(adapter, ERROR,

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -242,6 +242,12 @@ static int mwifiex_write_reg(struct mwifiex_adapter *adapter, int reg, u32 data)
 
 	iowrite32(data, card->pci_mmap1 + reg);
 
+	/* Do a read-back, which makes the write non-posted, ensuring the
+	 * completion before returning.
+	 * The firmware of the 88W8897 card is buggy and this avoids crashes.
+	 */
+	ioread32(card->pci_mmap1 + reg);
+
 	return 0;
 }
 

--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -2333,17 +2333,12 @@ int mwifiex_sta_init_cmd(struct mwifiex_private *priv, u8 first_sta, bool init)
 			return -1;
 
 		if (priv->bss_type != MWIFIEX_BSS_TYPE_UAP) {
-			/* Disable IEEE PS by default */
-			priv->adapter->ps_mode = MWIFIEX_802_11_POWER_MODE_CAM;
+			/* Enable IEEE PS by default */
+			priv->adapter->ps_mode = MWIFIEX_802_11_POWER_MODE_PSP;
 			ret = mwifiex_send_cmd(priv,
 					       HostCmd_CMD_802_11_PS_MODE_ENH,
-					       DIS_AUTO_PS, BITMAP_STA_PS, NULL,
+					       EN_AUTO_PS, BITMAP_STA_PS, NULL,
 					       true);
-			if (ret)
-				return -1;
-			ret = mwifiex_send_cmd(priv,
-					       HostCmd_CMD_802_11_PS_MODE_ENH,
-					       GET_PS, 0, NULL, false);
 			if (ret)
 				return -1;
 		}


### PR DESCRIPTION
The wifi firmware crashes are now fixed, so let's try reenabling wifi powersaving again, it's really important for power consumption and we should really try keeping it enabled.

Since @kitakar5525 mentioned in https://github.com/linux-surface/kernel/pull/70#issuecomment-726087363 that this causes connection issues on the SB1 and S3, I'd prefer if we could test this MR at least on one of those two devices before merging.