### PR TITLE
mwifiex: Ignore BTCOEX events from the firmware

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/sta_event.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_event.c
@@ -1057,9 +1057,7 @@ int mwifiex_process_sta_event(struct mwifiex_private *priv)
 							adapter->event_skb);
 		break;
 	case EVENT_BT_COEX_WLAN_PARA_CHANGE:
-		dev_dbg(adapter->dev, "EVENT: BT coex wlan param update\n");
-		mwifiex_bt_coex_wlan_param_update_event(priv,
-							adapter->event_skb);
+		dev_dbg(adapter->dev, "EVENT: ignoring BT coex wlan param update\n");
 		break;
 	case EVENT_RXBA_SYNC:
 		dev_dbg(adapter->dev, "EVENT: RXBA_SYNC\n");


### PR DESCRIPTION
The firmware of the pcie 88W8897 chip sends those events very
unreliably, which means we sometimes end up actually capping the window
size while bluetooth is disabled, artifically limiting wifi speeds even
though it's not needed.

Since we can't fix the firmware, let's just ignore those events, it
seems that the Windows driver also doesn't change the rx/tx block ack
buffer sizes when bluetooth gets enabled or disabled, so this is
consistent with the Windows driver.