### PR TITLE
Override irq7 for SL4A over probing Legacy PIC

### DIFF
--- a/arch/x86/kernel/acpi/boot.c
+++ b/arch/x86/kernel/acpi/boot.c
@@ -21,6 +21,7 @@
 #include <linux/efi-bgrt.h>
 #include <linux/serial_core.h>
 #include <linux/pgtable.h>
+#include <linux/dmi.h>
 
 #include <asm/e820/api.h>
 #include <asm/irqdomain.h>
@@ -1155,6 +1156,17 @@ static void __init mp_config_acpi_legacy_irqs(void)
 	}
 }
 
+static const struct dmi_system_id surface_quirk[] __initconst = {
+	{
+		.ident = "Microsoft Surface Laptop 4 (AMD)",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+			DMI_MATCH(DMI_PRODUCT_SKU, "Surface_Laptop_4_1952:1953")
+		},
+	},
+	{}
+};
+
 /*
  * Parse IOAPIC related entries in MADT
  * returns 0 on success, < 0 on error
@@ -1211,6 +1223,11 @@ static int __init acpi_parse_madt_ioapic_entries(void)
 	if (acpi_sci_override_gsi == INVALID_ACPI_IRQ && !acpi_gbl_reduced_hardware)
 		acpi_sci_ioapic_setup(acpi_gbl_FADT.sci_interrupt, 0, 0,
 				      acpi_gbl_FADT.sci_interrupt);
+
+	if (dmi_check_system(surface_quirk)) {
+		pr_warn("Surface hack: Override irq 7\n");
+		mp_override_legacy_irq(7, 3, 3, 7);
+	}
 
 	/* Fill in identity legacy mappings where no override */
 	mp_config_acpi_legacy_irqs();

--- a/arch/x86/kernel/i8259.c
+++ b/arch/x86/kernel/i8259.c
@@ -1,7 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0
-
-#define pr_fmt(fmt) "i8259: " fmt
-
 #include <linux/linkage.h>
 #include <linux/errno.h>
 #include <linux/signal.h>
@@ -19,7 +16,6 @@
 #include <linux/io.h>
 #include <linux/delay.h>
 #include <linux/pgtable.h>
-#include <linux/dmi.h>
 
 #include <linux/atomic.h>
 #include <asm/timer.h>
@@ -302,39 +298,11 @@ static void unmask_8259A(void)
 	raw_spin_unlock_irqrestore(&i8259A_lock, flags);
 }
 
-/*
- * DMI table to identify devices with quirky probe behavior. See comment in
- * probe_8259A() for more details.
- */
-static const struct dmi_system_id retry_probe_quirk_table[] = {
-	{
-		.ident = "Microsoft Surface Laptop 4 (AMD)",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
-			DMI_MATCH(DMI_PRODUCT_SKU, "Surface_Laptop_4_1952:1953")
-		},
-	},
-	{}
-};
-
 static int probe_8259A(void)
 {
 	unsigned long flags;
 	unsigned char probe_val = ~(1 << PIC_CASCADE_IR);
 	unsigned char new_val;
-	unsigned int i, imax = 1;
-
-	/*
-	 * Some systems have a legacy PIC that doesn't immediately respond
-	 * after boot. We know it's there, we know it should respond and is
-	 * required for proper interrupt handling later on, so let's try a
-	 * couple of times.
-	 */
-	if (dmi_check_system(retry_probe_quirk_table)) {
-		pr_warn("system with broken legacy PIC detected, re-trying multiple times if necessary\n");
-		imax = 10;
-	}
-
 	/*
 	 * Check to see if we have a PIC.
 	 * Mask all except the cascade and read
@@ -344,24 +312,15 @@ static int probe_8259A(void)
 	 */
 	raw_spin_lock_irqsave(&i8259A_lock, flags);
 
-	for (i = 0; i < imax; i++) {
-		outb(0xff, PIC_SLAVE_IMR);	/* mask all of 8259A-2 */
-		outb(probe_val, PIC_MASTER_IMR);
-		new_val = inb(PIC_MASTER_IMR);
-		if (new_val == probe_val)
-			break;
-	}
-
-	if (i == imax) {
-		pr_info("using NULL legacy PIC\n");
+	outb(0xff, PIC_SLAVE_IMR);	/* mask all of 8259A-2 */
+	outb(probe_val, PIC_MASTER_IMR);
+	new_val = inb(PIC_MASTER_IMR);
+	if (new_val != probe_val) {
+		printk(KERN_INFO "Using NULL legacy PIC\n");
 		legacy_pic = &null_legacy_pic;
 	}
 
 	raw_spin_unlock_irqrestore(&i8259A_lock, flags);
-
-	if (imax > 1 && i < imax)
-		pr_info("got legacy PIC after %d tries\n", i + 1);
-
 	return nr_legacy_irqs();
 }
 


### PR DESCRIPTION
From the mailing list [thread](https://lore.kernel.org/lkml/20210512210459.1983026-1-luzmaximilian@gmail.com/) it sounds like using a quirk to provide an override to the irq 7 interrupt for setup of the IOAPIC is a cleaner hack for the short term.

The two commits here revert the legacy PIC workaround, and copies Thomas Gleixner's debugging patch as a temporary solution.