### PR TITLE
platform/x86: amd-pmc: Add device HID for AMD PMC

### DIFF
--- a/drivers/platform/x86/amd-pmc.c
+++ b/drivers/platform/x86/amd-pmc.c
@@ -275,6 +275,7 @@ static int amd_pmc_remove(struct platform_device *pdev)
 static const struct acpi_device_id amd_pmc_acpi_ids[] = {
 	{"AMDI0005", 0},
 	{"AMD0004", 0},
+	{"AMD0005", 0},
 	{ }
 };
 MODULE_DEVICE_TABLE(acpi, amd_pmc_acpi_ids);


### PR DESCRIPTION
The Surface Laptop 4 appears to have used AMD0005 for the PMC instead of
the AMDI0005 which would match the ACPI ID Registry.

AMD appears to have previously used "AMD" in a number of IDs in the past,
and AMD is not allocated to any other entity as an ID, so adding this ID
should not cause any harm.

Signed-off-by: Sachi King <nakato@nakato.io>