### PR TITLE
Input: soc_button_array - support AMD variant Surface devices

### DIFF
--- a/drivers/input/misc/soc_button_array.c
+++ b/drivers/input/misc/soc_button_array.c
@@ -474,8 +474,8 @@ static const struct soc_device_data soc_device_INT33D3 = {
  * Both, the Surface Pro 4 (surfacepro3_button.c) and the above mentioned
  * devices use MSHW0040 for power and volume buttons, however the way they
  * have to be addressed differs. Make sure that we only load this drivers
- * for the correct devices by checking the OEM Platform Revision provided by
- * the _DSM method.
+ * for the correct devices by checking if the OEM Platform Revision DSM call
+ * exists.
  */
 #define MSHW0040_DSM_REVISION		0x01
 #define MSHW0040_DSM_GET_OMPR		0x02	// get OEM Platform Revision
@@ -486,31 +486,14 @@ static const guid_t MSHW0040_DSM_UUID =
 static int soc_device_check_MSHW0040(struct device *dev)
 {
 	acpi_handle handle = ACPI_HANDLE(dev);
-	union acpi_object *result;
-	u64 oem_platform_rev = 0;	// valid revisions are nonzero
+	bool exists;
 
-	// get OEM platform revision
-	result = acpi_evaluate_dsm_typed(handle, &MSHW0040_DSM_UUID,
-					 MSHW0040_DSM_REVISION,
-					 MSHW0040_DSM_GET_OMPR, NULL,
-					 ACPI_TYPE_INTEGER);
+	// check if OEM platform revision DSM call exists
+	exists = acpi_check_dsm(handle, &MSHW0040_DSM_UUID,
+				MSHW0040_DSM_REVISION,
+				BIT(MSHW0040_DSM_GET_OMPR));
 
-	if (result) {
-		oem_platform_rev = result->integer.value;
-		ACPI_FREE(result);
-	}
-
-	/*
-	 * If the revision is zero here, the _DSM evaluation has failed. This
-	 * indicates that we have a Pro 4 or Book 1 and this driver should not
-	 * be used.
-	 */
-	if (oem_platform_rev == 0)
-		return -ENODEV;
-
-	dev_dbg(dev, "OEM Platform Revision %llu\n", oem_platform_rev);
-
-	return 0;
+	return exists ? 0 : -ENODEV;
 }
 
 /*


### PR DESCRIPTION
The power button on the AMD variant of the Surface Laptop uses the
same MSHW0040 device ID as the 5th and later generation of Surface
devices, however they report 0 for their OEM platform revision.  As the
AMD variant's do not need any special casing, skip calling the _DSM and
continue loading the soc_button_array.

While only the power button is used in these laptops, the volume keys
are still defined in the ACPI table.