### PR TITLE
Move Surface Aggregator client devices on Surface Book 3 from base hub to KIP hub

### DIFF
--- a/drivers/platform/surface/surface_aggregator_registry.c
+++ b/drivers/platform/surface/surface_aggregator_registry.c
@@ -41,13 +41,7 @@ static const struct software_node ssam_node_root = {
 	.name = "ssam_platform_hub",
 };
 
-/* Base device hub (devices attached to Surface Book 3 base). */
-static const struct software_node ssam_node_hub_base = {
-	.name = "ssam:00:00:02:00:00",
-	.parent = &ssam_node_root,
-};
-
-/* KIP device hub (connects keyboard cover devices on Surface Pro 8). */
+/* KIP device hub (connects detachable keyboard/touchpad on Surface Pro 8 and Book 3). */
 static const struct software_node ssam_node_hub_kip = {
 	.name = "ssam:01:0e:01:00:00",
 	.parent = &ssam_node_root,
@@ -65,10 +59,10 @@ static const struct software_node ssam_node_bat_main = {
 	.parent = &ssam_node_root,
 };
 
-/* Secondary battery (Surface Book 3). */
-static const struct software_node ssam_node_bat_sb3base = {
+/* Secondary battery (Surface Book 3, managed via KIP hub). */
+static const struct software_node ssam_node_bat_kip = {
 	.name = "ssam:01:02:02:01:00",
-	.parent = &ssam_node_hub_base,
+	.parent = &ssam_node_hub_kip,
 };
 
 /* Platform profile / performance-mode device. */
@@ -143,30 +137,6 @@ static const struct software_node ssam_node_hid_main_iid5 = {
 	.parent = &ssam_node_root,
 };
 
-/* HID keyboard (base hub). */
-static const struct software_node ssam_node_hid_base_keyboard = {
-	.name = "ssam:01:15:02:01:00",
-	.parent = &ssam_node_hub_base,
-};
-
-/* HID touchpad (base hub). */
-static const struct software_node ssam_node_hid_base_touchpad = {
-	.name = "ssam:01:15:02:03:00",
-	.parent = &ssam_node_hub_base,
-};
-
-/* HID device instance 5 (unknown HID device, base hub). */
-static const struct software_node ssam_node_hid_base_iid5 = {
-	.name = "ssam:01:15:02:05:00",
-	.parent = &ssam_node_hub_base,
-};
-
-/* HID device instance 6 (unknown HID device, base hub). */
-static const struct software_node ssam_node_hid_base_iid6 = {
-	.name = "ssam:01:15:02:06:00",
-	.parent = &ssam_node_hub_base,
-};
-
 /* HID keyboard (KIP hub). */
 static const struct software_node ssam_node_hid_kip_keyboard = {
 	.name = "ssam:01:15:02:01:00",
@@ -191,6 +161,12 @@ static const struct software_node ssam_node_hid_kip_iid5 = {
 	.parent = &ssam_node_hub_kip,
 };
 
+/* HID device instance 6 (KIP hub, unknown HID device). */
+static const struct software_node ssam_node_hid_kip_iid6 = {
+	.name = "ssam:01:15:02:06:00",
+	.parent = &ssam_node_hub_kip,
+};
+
 /*
  * Devices for 5th- and 6th-generations models:
  * - Surface Book 2,
@@ -206,16 +182,16 @@ static const struct software_node *ssam_node_group_gen5[] = {
 /* Devices for Surface Book 3. */
 static const struct software_node *ssam_node_group_sb3[] = {
 	&ssam_node_root,
-	&ssam_node_hub_base,
+	&ssam_node_hub_kip,
 	&ssam_node_bat_ac,
 	&ssam_node_bat_main,
-	&ssam_node_bat_sb3base,
+	&ssam_node_bat_kip,
 	&ssam_node_tmp_pprof,
 	&ssam_node_bas_dtx,
-	&ssam_node_hid_base_keyboard,
-	&ssam_node_hid_base_touchpad,
-	&ssam_node_hid_base_iid5,
-	&ssam_node_hid_base_iid6,
+	&ssam_node_hid_kip_keyboard,
+	&ssam_node_hid_kip_touchpad,
+	&ssam_node_hid_kip_iid5,
+	&ssam_node_hid_kip_iid6,
 	NULL,
 };
 

--- a/drivers/platform/surface/surface_aggregator_registry.c
+++ b/drivers/platform/surface/surface_aggregator_registry.c
@@ -325,212 +325,6 @@ err:
 }
 
 
-/* -- SSAM base-hub driver. ------------------------------------------------- */
-
-/*
- * Some devices (especially battery) may need a bit of time to be fully usable
- * after being (re-)connected. This delay has been determined via
- * experimentation.
- */
-#define SSAM_BASE_UPDATE_CONNECT_DELAY		msecs_to_jiffies(2500)
-
-enum ssam_base_hub_state {
-	SSAM_BASE_HUB_UNINITIALIZED,
-	SSAM_BASE_HUB_CONNECTED,
-	SSAM_BASE_HUB_DISCONNECTED,
-};
-
-struct ssam_base_hub {
-	struct ssam_device *sdev;
-
-	enum ssam_base_hub_state state;
-	struct delayed_work update_work;
-
-	struct ssam_event_notifier notif;
-};
-
-SSAM_DEFINE_SYNC_REQUEST_R(ssam_bas_query_opmode, u8, {
-	.target_category = SSAM_SSH_TC_BAS,
-	.target_id       = 0x01,
-	.command_id      = 0x0d,
-	.instance_id     = 0x00,
-});
-
-#define SSAM_BAS_OPMODE_TABLET		0x00
-#define SSAM_EVENT_BAS_CID_CONNECTION	0x0c
-
-static int ssam_base_hub_query_state(struct ssam_base_hub *hub, enum ssam_base_hub_state *state)
-{
-	u8 opmode;
-	int status;
-
-	status = ssam_retry(ssam_bas_query_opmode, hub->sdev->ctrl, &opmode);
-	if (status < 0) {
-		dev_err(&hub->sdev->dev, "failed to query base state: %d\n", status);
-		return status;
-	}
-
-	if (opmode != SSAM_BAS_OPMODE_TABLET)
-		*state = SSAM_BASE_HUB_CONNECTED;
-	else
-		*state = SSAM_BASE_HUB_DISCONNECTED;
-
-	return 0;
-}
-
-static ssize_t ssam_base_hub_state_show(struct device *dev, struct device_attribute *attr,
-					char *buf)
-{
-	struct ssam_base_hub *hub = dev_get_drvdata(dev);
-	bool connected = hub->state == SSAM_BASE_HUB_CONNECTED;
-
-	return sysfs_emit(buf, "%d\n", connected);
-}
-
-static struct device_attribute ssam_base_hub_attr_state =
-	__ATTR(state, 0444, ssam_base_hub_state_show, NULL);
-
-static struct attribute *ssam_base_hub_attrs[] = {
-	&ssam_base_hub_attr_state.attr,
-	NULL,
-};
-
-static const struct attribute_group ssam_base_hub_group = {
-	.attrs = ssam_base_hub_attrs,
-};
-
-static void ssam_base_hub_update_workfn(struct work_struct *work)
-{
-	struct ssam_base_hub *hub = container_of(work, struct ssam_base_hub, update_work.work);
-	struct fwnode_handle *node = dev_fwnode(&hub->sdev->dev);
-	enum ssam_base_hub_state state;
-	int status = 0;
-
-	status = ssam_base_hub_query_state(hub, &state);
-	if (status)
-		return;
-
-	if (hub->state == state)
-		return;
-	hub->state = state;
-
-	if (hub->state == SSAM_BASE_HUB_CONNECTED)
-		status = ssam_hub_register_clients(&hub->sdev->dev, hub->sdev->ctrl, node);
-	else
-		ssam_remove_clients(&hub->sdev->dev);
-
-	if (status)
-		dev_err(&hub->sdev->dev, "failed to update base-hub devices: %d\n", status);
-}
-
-static u32 ssam_base_hub_notif(struct ssam_event_notifier *nf, const struct ssam_event *event)
-{
-	struct ssam_base_hub *hub = container_of(nf, struct ssam_base_hub, notif);
-	unsigned long delay;
-
-	if (event->command_id != SSAM_EVENT_BAS_CID_CONNECTION)
-		return 0;
-
-	if (event->length < 1) {
-		dev_err(&hub->sdev->dev, "unexpected payload size: %u\n", event->length);
-		return 0;
-	}
-
-	/*
-	 * Delay update when the base is being connected to give devices/EC
-	 * some time to set up.
-	 */
-	delay = event->data[0] ? SSAM_BASE_UPDATE_CONNECT_DELAY : 0;
-
-	schedule_delayed_work(&hub->update_work, delay);
-
-	/*
-	 * Do not return SSAM_NOTIF_HANDLED: The event should be picked up and
-	 * consumed by the detachment system driver. We're just a (more or less)
-	 * silent observer.
-	 */
-	return 0;
-}
-
-static int __maybe_unused ssam_base_hub_resume(struct device *dev)
-{
-	struct ssam_base_hub *hub = dev_get_drvdata(dev);
-
-	schedule_delayed_work(&hub->update_work, 0);
-	return 0;
-}
-static SIMPLE_DEV_PM_OPS(ssam_base_hub_pm_ops, NULL, ssam_base_hub_resume);
-
-static int ssam_base_hub_probe(struct ssam_device *sdev)
-{
-	struct ssam_base_hub *hub;
-	int status;
-
-	hub = devm_kzalloc(&sdev->dev, sizeof(*hub), GFP_KERNEL);
-	if (!hub)
-		return -ENOMEM;
-
-	hub->sdev = sdev;
-	hub->state = SSAM_BASE_HUB_UNINITIALIZED;
-
-	hub->notif.base.priority = INT_MAX;  /* This notifier should run first. */
-	hub->notif.base.fn = ssam_base_hub_notif;
-	hub->notif.event.reg = SSAM_EVENT_REGISTRY_SAM;
-	hub->notif.event.id.target_category = SSAM_SSH_TC_BAS,
-	hub->notif.event.id.instance = 0,
-	hub->notif.event.mask = SSAM_EVENT_MASK_NONE;
-	hub->notif.event.flags = SSAM_EVENT_SEQUENCED;
-
-	INIT_DELAYED_WORK(&hub->update_work, ssam_base_hub_update_workfn);
-
-	ssam_device_set_drvdata(sdev, hub);
-
-	status = ssam_device_notifier_register(sdev, &hub->notif);
-	if (status)
-		return status;
-
-	status = sysfs_create_group(&sdev->dev.kobj, &ssam_base_hub_group);
-	if (status)
-		goto err;
-
-	schedule_delayed_work(&hub->update_work, 0);
-	return 0;
-
-err:
-	ssam_device_notifier_unregister(sdev, &hub->notif);
-	cancel_delayed_work_sync(&hub->update_work);
-	ssam_remove_clients(&sdev->dev);
-	return status;
-}
-
-static void ssam_base_hub_remove(struct ssam_device *sdev)
-{
-	struct ssam_base_hub *hub = ssam_device_get_drvdata(sdev);
-
-	sysfs_remove_group(&sdev->dev.kobj, &ssam_base_hub_group);
-
-	ssam_device_notifier_unregister(sdev, &hub->notif);
-	cancel_delayed_work_sync(&hub->update_work);
-	ssam_remove_clients(&sdev->dev);
-}
-
-static const struct ssam_device_id ssam_base_hub_match[] = {
-	{ SSAM_VDEV(HUB, 0x02, SSAM_ANY_IID, 0x00) },
-	{ },
-};
-
-static struct ssam_device_driver ssam_base_hub_driver = {
-	.probe = ssam_base_hub_probe,
-	.remove = ssam_base_hub_remove,
-	.match_table = ssam_base_hub_match,
-	.driver = {
-		.name = "surface_aggregator_base_hub",
-		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
-		.pm = &ssam_base_hub_pm_ops,
-	},
-};
-
-
 /* -- SSAM KIP-subsystem hub driver. ---------------------------------------- */
 
 /*
@@ -872,10 +666,6 @@ static int __init ssam_device_hub_init(void)
 	if (status)
 		goto err_platform;
 
-	status = ssam_device_driver_register(&ssam_base_hub_driver);
-	if (status)
-		goto err_base;
-
 	status = ssam_device_driver_register(&ssam_kip_hub_driver);
 	if (status)
 		goto err_kip;
@@ -883,8 +673,6 @@ static int __init ssam_device_hub_init(void)
 	return 0;
 
 err_kip:
-	ssam_device_driver_unregister(&ssam_base_hub_driver);
-err_base:
 	platform_driver_unregister(&ssam_platform_hub_driver);
 err_platform:
 	return status;
@@ -894,7 +682,6 @@ module_init(ssam_device_hub_init);
 static void __exit ssam_device_hub_exit(void)
 {
 	ssam_device_driver_unregister(&ssam_kip_hub_driver);
-	ssam_device_driver_unregister(&ssam_base_hub_driver);
 	platform_driver_unregister(&ssam_platform_hub_driver);
 }
 module_exit(ssam_device_hub_exit);

--- a/drivers/power/supply/surface_battery.c
+++ b/drivers/power/supply/surface_battery.c
@@ -156,6 +156,9 @@ static bool spwr_battery_present(struct spwr_battery_device *bat)
 {
 	lockdep_assert_held(&bat->lock);
 
+	if (ssam_device_is_hot_removed(bat->sdev))
+		return false;
+
 	return le32_to_cpu(bat->sta) & SAM_BATTERY_STA_PRESENT;
 }
 
@@ -244,6 +247,9 @@ static int spwr_battery_update_bix_unlocked(struct spwr_battery_device *bat)
 	int status;
 
 	lockdep_assert_held(&bat->lock);
+
+	if (ssam_device_is_hot_removed(bat->sdev))
+		return 0;
 
 	status = spwr_battery_load_sta(bat);
 	if (status)


### PR DESCRIPTION
This moves the SSAM client devices attached to the Surface Book 3 base from the base hub to the KIP hub which seems to be the intended subsystem for managing those devices. With this change, the base hub becomes unused and can be removed.