### PR TITLE
Fixes for the ov8865 driver

### DIFF
--- a/drivers/media/i2c/ov8865.c
+++ b/drivers/media/i2c/ov8865.c
@@ -2535,7 +2535,7 @@ static int ov8865_ctrls_init(struct ov8865_sensor *sensor)
 
 	/* Gain */
 
-	v4l2_ctrl_new_std(handler, ops, V4L2_CID_ANALOGUE_GAIN, 128, 8191, 128,
+	v4l2_ctrl_new_std(handler, ops, V4L2_CID_ANALOGUE_GAIN, 128, 2048, 128,
 			  128);
 
 	/* White Balance */

--- a/drivers/media/i2c/ov8865.c
+++ b/drivers/media/i2c/ov8865.c
@@ -143,6 +143,7 @@
 #define OV8865_EXPOSURE_CTRL_L_REG		0x3502
 #define OV8865_EXPOSURE_CTRL_L(v)		((v) & GENMASK(7, 0))
 #define OV8865_EXPOSURE_GAIN_MANUAL_REG		0x3503
+#define OV8865_INTEGRATION_TIME_MARGIN		8
 
 #define OV8865_GAIN_CTRL_H_REG			0x3508
 #define OV8865_GAIN_CTRL_H(v)			(((v) & GENMASK(12, 8)) >> 8)
@@ -2462,7 +2463,8 @@ static int ov8865_s_ctrl(struct v4l2_ctrl *ctrl)
 	if (ctrl->id == V4L2_CID_VBLANK) {
 		int exposure_max;
 
-		exposure_max = sensor->state.mode->output_size_y + ctrl->val;
+		exposure_max = sensor->state.mode->output_size_y + ctrl->val -
+			       OV8865_INTEGRATION_TIME_MARGIN;
 		__v4l2_ctrl_modify_range(sensor->ctrls.exposure,
 					 sensor->ctrls.exposure->minimum,
 					 exposure_max,


### PR DESCRIPTION
Thanks to @jhautbois for spotting these. 

The black image problem people are having comes when the exposure set goes too close to the VTS. Most sensor drivers have some margin built in to prevent that, but I forgot to include that in the changes to the exposure control in ov8865. Add one in to avoid the black screen issue.

Opportunistically fix the max analogue gain. The field is 12 bits wide which is where the 8191 figure came from, but the driver specifies it as having a max of 16x gain