### PR TITLE
media: ipu3-cio2: Re-add .complete() to ipu3-cio2

### DIFF
--- a/drivers/media/pci/intel/ipu3/ipu3-cio2-main.c
+++ b/drivers/media/pci/intel/ipu3/ipu3-cio2-main.c
@@ -1429,9 +1429,18 @@ static void cio2_notifier_unbind(struct v4l2_async_notifier *notifier,
 	cio2->queue[s_asd->csi2.port].sensor = NULL;
 }
 
+/* .complete() is called after all subdevices have been located */
+static int cio2_notifier_complete(struct v4l2_async_notifier *notifier)
+{
+	struct cio2_device *cio2 = to_cio2_device(notifier);
+
+	return v4l2_device_register_subdev_nodes(&cio2->v4l2_dev);
+}
+
 static const struct v4l2_async_notifier_operations cio2_async_ops = {
 	.bound = cio2_notifier_bound,
 	.unbind = cio2_notifier_unbind,
+	.complete = cio2_notifier_complete,
 };
 
 static int cio2_parse_firmware(struct cio2_device *cio2)


### PR DESCRIPTION
This should fix the always-broken VCMs and allow cameras to work again everywhere. The VCM itself may still not work - it will depend on probe ordering, I still need to fix the missing propagation for the -EPROBE_DEFER call in the cio2-bridge. 

Sorry this took so long - I thought it was broken in some way as I couldn't get the focus to work but after extensive debugging it turned out I was just being an utter moron :D