### PR TITLE
add wdk2023 acpi to smmu platlist

### DIFF
--- a/drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c
+++ b/drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c
@@ -446,6 +446,7 @@ static const struct of_device_id __maybe_unused qcom_smmu_impl_of_match[] = {
 static struct acpi_platform_list qcom_acpi_platlist[] = {
 	{ "LENOVO", "CB-01   ", 0x8180, ACPI_SIG_IORT, equal, "QCOM SMMU" },
 	{ "QCOM  ", "QCOMEDK2", 0x8180, ACPI_SIG_IORT, equal, "QCOM SMMU" },
+	{ "QCOM  ", "QCOMEDK2", 0x8280, ACPI_SIG_IORT, equal, "QCOM SMMU" },
 	{ }
 };
 #endif


### PR DESCRIPTION
We need to inform the SMMU driver of our ACPI for booting in ACPI mode to work on Windows Dev Kit 2023