### PR TITLE
platform/x86: int3472: Remap reset GPIO for INT347E

### DIFF
--- a/drivers/platform/x86/intel/int3472/discrete.c
+++ b/drivers/platform/x86/intel/int3472/discrete.c
@@ -108,6 +108,9 @@ static int skl_int3472_map_gpio_to_sensor(struct int3472_discrete_device *int347
 {
 	const struct int3472_sensor_config *sensor_config;
 	char *path = agpio->resource_source.string_ptr;
+	const struct acpi_device_id ov7251_ids[] = {
+		{ "INT347E" },
+	};
 	struct gpiod_lookup *table_entry;
 	struct acpi_device *adev;
 	acpi_handle handle;
@@ -128,6 +131,17 @@ static int skl_int3472_map_gpio_to_sensor(struct int3472_discrete_device *int347
 				break;
 			}
 		}
+	}
+
+	/*
+	 * In addition to the function remap table we need to bulk remap the
+	 * "reset" GPIO for the OmniVision 7251 sensor, as the driver for that
+	 * expects its only GPIO pin to be called "enable" (and to have the
+	 * opposite polarity).
+	 */
+	if (!strcmp(func, "reset") && !acpi_match_device_ids(int3472->sensor, ov7251_ids)) {
+		func = "enable";
+		polarity = GPIO_ACTIVE_HIGH;
 	}
 
 	/* Functions mapped to NULL should not be mapped to the sensor */


### PR DESCRIPTION
ACPI _HID INT347E represents the OmniVision 7251 camera sensor. The driver for this sensor expects a single pin named "enable", but on some Microsoft Surface platforms the sensor is assigned a single GPIO who's type flag is INT3472_GPIO_TYPE_RESET.

Remap the GPIO pin's function from "reset" to "enable". This is done outside of the existing remap table since it is a more widespread discrepancy than that method is designed for. Additionally swap the polarity of the pin to match the driver's expectation.