### PR TITLE
Update IPTS from module repo

### DIFF
--- a/drivers/hid/ipts/receiver.c
+++ b/drivers/hid/ipts/receiver.c
@@ -42,7 +42,7 @@ static void ipts_receiver_backoff(time64_t last, u32 n)
 	 * n seconds, sleep longer to avoid wasting CPU cycles.
 	 */
 	if (last + n > ktime_get_seconds())
-		msleep(20);
+		usleep_range(1 * USEC_PER_MSEC, 5 * USEC_PER_MSEC);
 	else
 		msleep(200);
 }

--- a/drivers/hid/ipts/resources.h
+++ b/drivers/hid/ipts/resources.h
@@ -31,6 +31,9 @@ struct ipts_resources {
 	struct ipts_buffer hid2me;
 
 	struct ipts_buffer descriptor;
+
+	// Buffer for synthesizing HID reports
+	struct ipts_buffer report;
 };
 
 int ipts_resources_init(struct ipts_resources *res, struct device *dev, size_t ds, size_t fs);


### PR DESCRIPTION
Changes:
 * Fix redefinition error on AOSP clang
 * Increase the polling frequency to reduce latency
 * Don't allocate a new buffer for every HID report
 * Always use the generic HID driver instead of forcing hid-multitouch

Based on https://github.com/linux-surface/intel-precise-touch/commit/a2b675d72dbde80ebe36a5b6ceaebd596c030314