### PR TITLE
Added patch to allow optional hibernate during lockdown

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -3000,6 +3000,11 @@
 			to extract confidential information from the kernel
 			are also disabled.
 
+	lockdown_hibernate	[HIBERNATION]
+			Enable hibernation even if lockdown is enabled. Enable this only if
+			your swap is encrypted and secured properly, as an attacker can
+			modify the kernel offline during hibernation.
+
 	locktorture.acq_writer_lim= [KNL]
 			Set the time limit in jiffies for a lock
 			acquisition.  Acquisitions exceeding this limit

--- a/kernel/power/hibernate.c
+++ b/kernel/power/hibernate.c
@@ -37,6 +37,7 @@
 #include "power.h"
 
 
+static int lockdown_hibernate;
 static int nocompress;
 static int noresume;
 static int nohibernate;
@@ -92,7 +93,7 @@ void hibernate_release(void)
 bool hibernation_available(void)
 {
 	return nohibernate == 0 &&
-		!security_locked_down(LOCKDOWN_HIBERNATION) &&
+		(lockdown_hibernate || !security_locked_down(LOCKDOWN_HIBERNATION)) &&
 		!secretmem_active() && !cxl_mem_active();
 }
 
@@ -1422,6 +1423,12 @@ static int __init nohibernate_setup(char *str)
 	return 1;
 }
 
+static int __init lockdown_hibernate_setup(char *str)
+{
+	lockdown_hibernate = 1;
+	return 1;
+}
+
 static const char * const comp_alg_enabled[] = {
 #if IS_ENABLED(CONFIG_CRYPTO_LZO)
 	COMPRESSION_ALGO_LZO,
@@ -1480,3 +1487,4 @@ __setup("hibernate=", hibernate_setup);
 __setup("resumewait", resumewait_setup);
 __setup("resumedelay=", resumedelay_setup);
 __setup("nohibernate", nohibernate_setup);
+__setup("lockdown_hibernate", lockdown_hibernate_setup);


### PR DESCRIPTION
Expose an optional lockdown_hibernate kernel parameter to enable hibernation during kernel lockdown mode. The patch was imported from [here](https://gist.github.com/brknkfr/95d1925ccdbb7a2d18947c168dfabbee).

Closes https://github.com/linux-surface/linux-surface/issues/1543